### PR TITLE
[Usability] Add tooltip to "Edit" -> "Expect" when disabled

### DIFF
--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -211,10 +211,21 @@ sub _initGUI {
 
 sub __checkRBAuth {
 	my $self = shift;
-	
+
 	if ( _( $self, 'comboMethod' ) -> get_active_text !~ /RDP|VNC|Generic|3270/go ) {
-		_( $self, 'frameExpect' )	-> set_sensitive( ! _( $self, 'rbCfgAuthManual' ) -> get_active );
-		_( $self, 'labelExpect' )	-> set_sensitive( ! _( $self, 'rbCfgAuthManual' ) -> get_active );
+		if( _( $self, 'rbCfgAuthManual' ) -> get_active ) {
+			_( $self, 'frameExpect' )->set_sensitive( 0 );
+			_( $self, 'labelExpect' )->set_sensitive( 0 );
+			_( $self, 'labelExpect' )->set_tooltip_text("Authentication is set to Manual.\nExpect disabled.");
+			_( $self, 'alignExpect' )->set_tooltip_text("Authentication is set to Manual.\nExpect disabled.");
+		}
+		else{
+			_( $self, 'frameExpect' )->set_sensitive( 1 );
+			_( $self, 'labelExpect' )->set_sensitive( 1 );
+			_( $self, 'labelExpect' )->set_tooltip_text("EXPECT remote patterns AND-THEN-EXECUTE remote commands");
+			_( $self, 'alignExpect' )->set_has_tooltip( 0 );
+
+		}
 	}
 	
 	_( $self, 'alignUserPass' )		-> set_sensitive( _( $self, 'rbCfgAuthUserPass' ) -> get_active );

--- a/res/pac.glade
+++ b/res/pac.glade
@@ -7681,7 +7681,6 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="has_tooltip">True</property>
-                    <property name="tooltip" translatable="yes">EXPECT remote patterns AND-THEN-EXECUTE remote commands</property>
                     <property name="label" translatable="yes">Expect</property>
                   </widget>
                   <packing>


### PR DESCRIPTION
When Authentication is set to Manual in the "Edit Connection" dialogue, the "Expect" tab is disabled.
As a newcomer I didn't realize that it was the Manual setting that disabled it, I just wanted Expect automation even if the password was not stored in the connection settings.
In fact the meaning of "Manual" means that all automation is turned off, which is perfectly sensible when you think about it.

This patch makes the connection between Manual authentication and the disabled expect tab visible to the user by not only changing the "sensitive" setting of the tab (greying it out), but also setting the tool-tip of the tab when authentication mode is changed.  
