### PR TITLE
[Bugfix] - User variables doesn't work

### DIFF
--- a/lib/PACConfig.pm
+++ b/lib/PACConfig.pm
@@ -297,7 +297,7 @@ sub _setupCallbacks {
 			# Populate with user defined variables
 			my @variables_menu;
 			my $i = 0;
-			foreach my $value ( @{ $$self{variables} } ) {
+			foreach my $value ( map{ $_->{txt} // '' } @{ $$self{variables} } ) {
 				my $j = $i;
 				push( @variables_menu, {
 					label => "<V:$j> ($value)",

--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -353,7 +353,7 @@ sub _setupCallbacks {
 		# Populate with user defined variables
 		my @variables_menu;
 		my $i = 0;
-		foreach my $value ( @{ $$self{variables} } ) {
+		foreach my $value ( map{ $_->{txt} // '' } @{ $self->{_VARIABLES}->{cfg} } ) {
 			my $j = $i;
 			push( @variables_menu, {
 				label => "<V:$j> ($value)",
@@ -363,7 +363,7 @@ sub _setupCallbacks {
 		}
 		push( @menu_items, {
 			label => 'User variables...',
-			sensitive => scalar @{ $$self{variables} },
+			sensitive => scalar @{ $self->{_VARIABLES}->{cfg} },
 			submenu => \@variables_menu
 		} );
 		
@@ -476,7 +476,7 @@ sub _setupCallbacks {
 			# Populate with user defined variables
 			my @variables_menu;
 			my $i = 0;
-			foreach my $value ( @{ $$self{variables} } ) {
+			foreach my $value ( map{ $_->{txt} // '' } @{ $self->{_VARIABLES}->{cfg} } ) {
 				my $j = $i;
 				push( @variables_menu, {
 					label => "<V:$j> ($value)",
@@ -486,7 +486,7 @@ sub _setupCallbacks {
 			}
 			push( @menu_items, {
 				label => 'User variables...',
-				sensitive => scalar @{ $$self{variables} },
+				sensitive => scalar @{ $self->{_VARIABLES}->{cfg} },
 				submenu => \@variables_menu
 			} );
 			

--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -2210,7 +2210,7 @@ sub _treeConnections_menu_lite {
 	# Quick Edit variables
 	my @var_submenu;
 	my $i = 0;
-	foreach my $var ( @{ $$self{_CFG}{'environments'}{$sel[0]}{'variables'} } ) {
+	foreach my $var ( map{ $_->{txt} // '' } @{ $$self{_CFG}{'environments'}{$sel[0]}{'variables'} } ) {
 
 		my $j = $i;
 		
@@ -2226,7 +2226,7 @@ sub _treeConnections_menu_lite {
 					$var
 				);
 				! defined $new_var and return 1;
-				$$self{_CFG}{'environments'}{$sel[0]}{'variables'}[$j] = $new_var;
+				$$self{_CFG}{'environments'}{$sel[0]}{'variables'}[$j]{txt} = $new_var;
 			}
 		} );
 		
@@ -2430,7 +2430,7 @@ sub _treeConnections_menu {
 	# Quick Edit variables
 	my @var_submenu;
 	my $i = 0;
-	foreach my $var ( @{ $$self{_CFG}{'environments'}{$sel[0]}{'variables'} } ) {
+	foreach my $var ( map{ $_->{txt} // '' } @{ $$self{_CFG}{'environments'}{$sel[0]}{'variables'} } ) {
 
 		my $j = $i;
 		
@@ -2446,7 +2446,7 @@ sub _treeConnections_menu {
 					$var
 				);
 				! defined $new_var and return 1;
-				$$self{_CFG}{'environments'}{$sel[0]}{'variables'}[$j] = $new_var;
+				$$self{_CFG}{'environments'}{$sel[0]}{'variables'}[$j]{txt} = $new_var;
 			}
 		} );
 		

--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -244,6 +244,8 @@ sub new {
 			} );
 		}
 	}
+	#Accessability shortcuts
+	$$self{variables}=$$self{_CFG}{environments}{$$self{_UUID}}{variables};
 	
 	bless( $self, $class );
 	return $self;
@@ -1530,7 +1532,7 @@ sub _vteMenu {
 	# Populate with user defined variables
 	my @variables_menu;
 	my $i = 0;
-	foreach my $value ( @{ $$self{variables} } ) {
+	foreach my $value ( map{ $_->{txt} // '' } @{ $$self{variables} } ) {
 		my $j = $i;
 		push( @variables_menu,
 		{

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -2608,7 +2608,7 @@ sub _subst {
 		while ( $string =~ /<V:(\d+?)>/go ) {
 			my $var = $1;
 			if ( defined $$CFG{'environments'}{$uuid}{'variables'}[ $var ] ) {
-				my $val = $$CFG{'environments'}{$uuid}{'variables'}[ $var ] // '';
+				my $val = $$CFG{'environments'}{$uuid}{'variables'}[ $var ]{txt} // '';
 				$string =~ s/<V:$var>/$val/g;
 				$ret = $string;
 			}

--- a/lib/edit/PACExecEntry.pm
+++ b/lib/edit/PACExecEntry.pm
@@ -296,7 +296,7 @@ sub _buildExec {
 		# Populate with user defined variables
 		my @variables_menu;
 		my $i = 0;
-		foreach my $value ( @{ $$self{variables} } ) {
+		foreach my $value ( map{ $_->{txt} // '' } @{ $$self{variables} } ) {
 			my $j = $i;
 			push( @variables_menu,
 			{

--- a/lib/edit/PACExpectEntry.pm
+++ b/lib/edit/PACExpectEntry.pm
@@ -625,7 +625,7 @@ sub _buildExpect {
 		# Populate with user defined variables
 		my @variables_menu;
 		my $i = 0;
-		foreach my $value ( @{ $$self{variables} } ) {
+		foreach my $value ( map{ $_->{txt} // '' } @{ $$self{variables} } ) {
 			my $j = $i;
 			push( @variables_menu, {
 				label => "<V:$j> ($value)",
@@ -742,7 +742,7 @@ sub _buildExpect {
 		# Populate with user defined variables
 		my @variables_menu;
 		my $i = 0;
-		foreach my $value ( @{ $$self{variables} } ) {
+		foreach my $value ( map{ $_->{txt} // '' } @{ $$self{variables} } ) {
 			my $j = $i;
 			push( @variables_menu, {
 				label => "<V:$j> ($value)",

--- a/lib/edit/PACPrePostEntry.pm
+++ b/lib/edit/PACPrePostEntry.pm
@@ -255,7 +255,7 @@ sub _buildPrePost {
 		# Populate with user defined variables
 		my @variables_menu;
 		my $i = 0;
-		foreach my $value ( @{ $$self{variables} } ) {
+		foreach my $value ( map{ $_->{txt} // '' } @{ $$self{variables} } ) {
 			my $j = $i;
 			push( @variables_menu, {
 				label => "<V:$j> ($value)",

--- a/lib/pac_conn
+++ b/lib/pac_conn
@@ -382,7 +382,7 @@ sub subst {
 	while ( $string =~ /<V:(\d+?)>/go ) {
 		my $var = $1;
 		if ( defined $$CFG{'environments'}{$UUID}{'variables'}[ $var ] ) {
-			my $val = $$CFG{'environments'}{$UUID}{'variables'}[ $var ] // '';
+			my $val = $$CFG{'environments'}{$UUID}{'variables'}[ $var ]{txt} // '';
 			$string =~ s/<V:$var>/$val/g;
 		}
 	}


### PR DESCRIPTION
This fixes Issue #28.
Technically the problem was that: 
  - The {txt} hash key was not referenced when replacing user variables

As the User Variables have been broken in PAC since forever it seems, I guess people do not use it.
Here's how I use it:
 Create a template connection, with values as <V:0>, <V:1> wherever unique values are needed, such as ip-address, jump hosts, proxies and user name. Then just copy the connection and change all the connection unique values on the User Variables tab, instead of hunting down the different places that needs to be changed.

  https://sourceforge.net/p/pacmanager/bugs/249/
  Issue https://github.com/asbru-cm/asbru-cm/issues/28