### PR TITLE
Removed deprecated "have" function

### DIFF
--- a/res/asbru_bash_completion
+++ b/res/asbru_bash_completion
@@ -3,7 +3,6 @@ _asbru_commands()
 	asbru-cm --help | sed -e '1,/^Options:/d' -e '/^See /Q' -e 's/^[\t]\+\(--[^=]\+\)\(=.\+\)* : .*/\1/g' -e 's/^\(.\+\)=.\+/\1=/g' | uniq
 }
 
-have asbru-cm &&
 _asbru()
 {
 	cur=${COMP_WORDS[COMP_CWORD]}
@@ -18,5 +17,4 @@ _asbru()
 	COMPREPLY=( $( compgen -W "$options" -- ${cur} ) )
 }
 
-[ "$have" ] && complete -F _asbru asbru-cm
-
+complete -F _asbru asbru-cm


### PR DESCRIPTION
The "have" function in bash-completion is deprecated. Indeed, using this results in completions not working.

See the [Gentoo Wiki](https://wiki.gentoo.org/wiki/Bash/Installing_completion_files) for example.