### PR TITLE
Usability fixes: split window, append group name semantics

### DIFF
--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -2364,6 +2364,9 @@ sub _split {
 	my $uuid_tmp	= shift;
 	my $vertical	= shift // '0';
 	
+	# NOTE: For some reason the vertical flag is negated
+	$vertical = ! $vertical;
+
 	my $tabs = $self -> {_NOTEBOOK};
 	$$self{_SPLIT_VERTICAL} = $vertical;
 	

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -1417,7 +1417,7 @@ sub _wAddRenameNode {
 	} elsif ( $action eq 'add' ) {
 		$name			= '';
 		$parent_name	= $$cfg{'environments'}{ $uuid }{'name'};
-		$title			= $uuid eq '__PAC__ROOT__' || ! $$cfg{defaults}{'append group name'} ? '' : ($parent_name eq '' ? '' : "$parent_name - ");
+		$title			= $uuid eq '__PAC__ROOT__' || ! $$cfg{defaults}{'append group name'} ? '' : ($parent_name eq '' ? '' : " - $parent_name");
 		$lblup			= "<b>Adding new node into '" . ( $uuid eq '__PAC__ROOT__' ? 'ROOT' : "$parent_name" ) . "'</b>";
 	}
 	
@@ -1471,7 +1471,8 @@ sub _wAddRenameNode {
 			$w{window}{gui}{entry1} -> set_text( $name );
 			$w{window}{gui}{entry1} -> set_activates_default( 1 );
 			$w{window}{gui}{entry1} -> signal_connect( 'changed', sub {
-				$w{window}{gui}{entry2} -> set_text( ( $uuid eq '__PAC__ROOT__' || ! $$cfg{defaults}{'append group name'} ? '' : ($parent_name eq '' ? '' : "$parent_name - ") ) . $w{window}{gui}{entry1} -> get_chars( 0, -1 ) );
+				$w{window}{gui}{entry2} -> set_text( $w{window}{gui}{entry1} -> get_chars( 0, -1 ) . ( $uuid eq '__PAC__ROOT__' || ! $$cfg{defaults}{'append group name'} ? '' : ($parent_name eq '' ? '' :  " - $parent_name" ) ) );
+
 			} );
 		
 		# Create an HBox to contain a label and an entry


### PR DESCRIPTION
Two fixes:

    The split window semantics. In the present version the split semantics are swapped (vertically splits horizontally). This is fixed.

    The "automatically append group name to tittle for new connections" semantics. In the present version the group name is prefixed. This is fixed.
