### PR TITLE
update split panes separator handling

### DIFF
--- a/lib/PACConfig.pm
+++ b/lib/PACConfig.pm
@@ -519,6 +519,7 @@ sub _updateGUIPreferences {
 	#_( $self, 'btnCfgLocation' )			-> set_uri( 'file://' . $$self{_CFG}{'defaults'}{'config location'} );
 	_( $self, 'cbCfgAutoAcceptKeys' )		-> set_active( $$cfg{'defaults'}{'auto accept key'} );
 	_( $self, 'cbCfgHideOnConnect' )		-> set_active( $$cfg{'defaults'}{'hide on connect'} );
+	_( $self, 'cbCfgForceSpitSize' )		-> set_active( $$cfg{'defaults'}{'force split tabs to 50%'} );
 	_( $self, 'cbCfgCloseToTray' )			-> set_active( $$cfg{'defaults'}{'close to tray'} );
 	_( $self, 'cbCfgStartMainMaximized' )	-> set_active( $$cfg{'defaults'}{'start main maximized'} );
 	_( $self, 'cbCfgRememberSize' )			-> set_active( $$cfg{'defaults'}{'remember main size'} );
@@ -729,6 +730,7 @@ sub _saveConfiguration {
 	$$self{_CFG}{'defaults'}{'auto hide connections list'}		= _( $self, 'cbCfgConnectionsAutoHide' )	-> get_active;
 	$$self{_CFG}{'defaults'}{'auto hide button bar'}			= _( $self, 'cbCfgButtonBarAutoHide' )		-> get_active;
 	$$self{_CFG}{'defaults'}{'hide on connect'}					= _( $self, 'cbCfgHideOnConnect' ) 			-> get_active;
+	$$self{_CFG}{'defaults'}{'force split tabs to 50%'}					= _( $self, 'cbCfgForceSpitSize' ) 			-> get_active;
 	$$self{_CFG}{'defaults'}{'ping port before connect'}		= _( $self, 'cbCfgPreConnPingPort' )		-> get_active;
 	$$self{_CFG}{'defaults'}{'ping port timeout'}				= _( $self, 'spCfgPingTimeout' )			-> get_chars( 0, -1 );
 	$$self{_CFG}{'defaults'}{'start iconified'}					= _( $self, 'cbCfgStartIconified' )			-> get_active;

--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -1420,6 +1420,13 @@ sub _vteMenu {
 				tooltip		=> "Remove the split view and put each connection into its own tab",
 				code		=> sub { $self -> _unsplit; }
 			} );
+			push( @vte_menu_items,
+			{
+				label		=> 'Equally resize terminals',
+				stockicon	=> 'gtk-zoom-fit',
+				tooltip		=> "Resize terminals equally",
+				code		=> sub { $self -> _equalresize; }
+			} );
 		} else {
 			push( @vte_menu_items,
 			{
@@ -2268,6 +2275,12 @@ sub _tabMenu {
 					stockicon	=> 'gtk-zoom-fit',
 					code		=> sub { $self -> _unsplit; }
 				} );
+				push( @vte_menu_items,
+				{
+					label		=> 'Equally resize terminals',
+					stockicon	=> 'gtk-zoom-fit',
+					code		=> sub { $self -> _equalresize; }
+				} );
 			} else {
 				push( @vte_menu_items,
 				{
@@ -2455,9 +2468,25 @@ sub _split {
 	$self -> _setTabColour;
 	$PACMain::RUNNING{$uuid_tmp}{terminal} -> _updateCFG;
 
-	my $req = $$self{_GUI}{_VBOX} -> get_parent -> size_request;
+	my $req = $$self{_SPLIT_VPANE} -> get_parent -> allocation;
 	my ( $x, $y ) = ( $req -> width, $req -> height );
-	$$self{_SPLIT_VPANE} -> set_position( ( $vertical ? $y : $x ) / 1.3 );
+	$$self{_SPLIT_VPANE} -> set_position( ( ( $vertical ? $y : $x ) / 2 ) - 7 );
+
+	if ( $$self{_CFG}{'defaults'}{'force split tabs to 50%'} ) {
+		$$self{_SPLIT_VPANE} -> signal_connect( 'size-allocate', sub {
+			$self -> _equalresize ();
+		} );
+	}
+
+	return 1;
+}
+
+sub _equalresize {
+	my $self = shift;
+
+	my $req = $$self{_SPLIT_VPANE} -> get_parent -> allocation;
+	my ( $x, $y ) = ( $req -> width, $req -> height );
+	$$self{_SPLIT_VPANE} -> set_position( ( ( $$self{_SPLIT_VERTICAL} ? $y : $x ) / 2 ) - 7 );
 
 	return 1;
 }

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -1826,6 +1826,7 @@ sub _cfgSanityCheck {
 	$$cfg{'defaults'}{'auto hide connections list'}		//= 0;
 	$$cfg{'defaults'}{'auto hide button bar'}		    //= 0;
 	$$cfg{'defaults'}{'hide on connect'}				//= 0;
+	$$cfg{'defaults'}{'force split tabs to 50%'}				//= 0;
 	$$cfg{'defaults'}{'ping port before connect'}		//= 0;
 	$$cfg{'defaults'}{'ping port timeout'}				//= 1;
 	$$cfg{'defaults'}{'open connections in tabs'}		//= 1;

--- a/res/pac.glade
+++ b/res/pac.glade
@@ -495,6 +495,21 @@
                     </child>
                     -->
                     <child>
+                      <widget class="GtkCheckButton" id="cbCfgForceSpitSize">
+                        <property name="label" translatable="yes">Force slit tabs to 50%</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_action_appearance">False</property>
+                        <property name="draw_indicator">True</property>
+                      </widget>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
                       <widget class="GtkCheckButton" id="cbCfgHideOnConnect">
                         <property name="label" translatable="yes">Hide on connection</property>
                         <property name="visible">True</property>

--- a/res/pac.yml
+++ b/res/pac.yml
@@ -12,6 +12,7 @@ defaults:
   disconnected color: '#ffff00000000'
   global variables: {}
   hide on connect: ''
+  force split tabs to 50%: 0
   intro reconnects: ''
   minimize to tray: ''
   new data color: '#00008888ffff'


### PR DESCRIPTION
Hello,
I changed how the separator in split panels is set and managed.

1. On split panels creation the separator is now set in the middle, instead of being closer to the left side.
2. There's a new menu item to reposition the separator in the middle after the window is resized.
3. There's also a new option in the global settings to force the separator to stay in the middle when the window is resized.

There's one thing I'm not sure about:
```perl
$$self{_SPLIT_VPANE} -> set_position( ( ( $vertical ? $y : $x ) / 2 ) - 7 );
$$self{_SPLIT_VPANE} -> set_position( ( ( $$self{_SPLIT_VERTICAL} ? $y : $x ) / 2 ) - 7 );
```
that " - 7" is there to compensate the width of the separator itself, so that when I do "tput cols" on both terminals they return the same number of columns.
But I guess that on other os, or with a different gtk theme, the separator could be thinner/thicker.
Do you think there's any way to put the separator exactly in the middle and have 2 terminals with the same number of columns?
Thanks