### PR TITLE
Improving RDP methods

### DIFF
--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -546,13 +546,6 @@ sub _initGUI {
 
 				$$self{_GUI}{_SOCKET} = Gtk2::Socket -> new;
 				$sc2 -> add_with_viewport( $$self{_GUI}{_SOCKET} );
-
-			$$self{_GUI}{_BTNFOCUS} = Gtk2::Button -> new_with_mnemonic( 'Set _keyboard focus' );
-			$$self{_GUI}{_BTNFOCUS} -> set_image( Gtk2::Image -> new_from_icon_name( 'input-keyboard', 'GTK_ICON_SIZE_SMALL_TOOLBAR' ) );
-			$$self{_GUI}{_BTNFOCUS} -> set( 'can_focus', 0 );
-			$$self{_GUI}{_VBOX} -> pack_start( $$self{_GUI}{_BTNFOCUS}, 0, 1, 0 );
-
-			$$self{FOCUS} = $$self{_GUI}{_SOCKET};
 		}
 
 		#### $vbox 2nd row: this will contain local/remote macros
@@ -642,6 +635,15 @@ sub _initGUI {
 			$$self{_GUI}{btnShowInfoTab} -> set_image( Gtk2::Image -> new_from_stock( 'gtk-info', 'GTK_ICON_SIZE_BUTTON' ));
 			$$self{_GUI}{btnShowInfoTab} -> set_tooltip_text( 'Show information tab (Shift+Ctrl+I)' );
 			$$self{_GUI}{bottombox} -> pack_end( $$self{_GUI}{btnShowInfoTab}, 0, 1, 4 );
+
+		if ( $$self{'EMBED'} ) {
+			$$self{_GUI}{_BTNFOCUS} = Gtk2::Button -> new_with_mnemonic( 'Set _keyboard focus' );
+			$$self{_GUI}{_BTNFOCUS} -> set_image( Gtk2::Image -> new_from_icon_name( 'input-keyboard', 'GTK_ICON_SIZE_BUTTON' ) );
+			$$self{_GUI}{_BTNFOCUS} -> set( 'can_focus', 0 );
+			$$self{_GUI}{bottombox} -> pack_end( $$self{_GUI}{_BTNFOCUS}, 0, 1, 4 );
+				
+			$$self{FOCUS} = $$self{_GUI}{_SOCKET};
+		}
 
 			# Create gtkstatusbar
 			$$self{_GUI}{status} = Gtk2::Statusbar -> new;

--- a/lib/method/PACMethod_rdesktop.pm
+++ b/lib/method/PACMethod_rdesktop.pm
@@ -41,7 +41,7 @@ use Gtk2 '-init';
 # Define GLOBAL CLASS variables
 
 my %RDP_VERSION = ( 4 => 0, 5 => 1 );
-my %BPP 		= ( 8 => 0, 15 => 1, 16 => 2, 24 => 3 );
+my %BPP 		= ( 8 => 0, 15 => 1, 16 => 2, 24 => 3, 32 => 4 );
 my %SOUND		= ( 'local' => 0, 'off' => 1, 'remote' => 2 );
 
 my $RES_DIR = $RealBin . '/res';
@@ -77,7 +77,7 @@ sub update {
 	my $options = _parseCfgToOptions( $$self{cfg});
 	
 	$$self{gui}{cbRDPVersion}			-> set_active( $RDP_VERSION{ $$options{RDPVersion} // 5 } );
-	$$self{gui}{cbBPP}					-> set_active( $BPP{ $$options{bpp} // 8 } );
+	$$self{gui}{cbBPP}					-> set_active( $BPP{ $$options{bpp} // 24 } );
 	$$self{gui}{chClipboard}			-> set_active( $$options{clipboard} // 1 );
 	$$self{gui}{chAttachToConsole}		-> set_active( $$options{attachToConsole} );
 	$$self{gui}{chBitmapCaching}		-> set_active( $$options{bitmapCaching} );
@@ -158,7 +158,7 @@ sub _parseCfgToOptions {
 	
 	my %hash;
 	$hash{RDPVersion}		= 5;
-	$hash{bpp}				= 8;
+	$hash{bpp}				= 24;
 	$hash{clipboard}		= 1;
 	$hash{attachToConsole}	= 0;
 	$hash{bitmapCaching}	= 0;
@@ -185,7 +185,7 @@ sub _parseCfgToOptions {
 		$opt =~ s/\s+$//go;
 		
 		$opt =~ /^(4|5)$/go					and	$hash{RDPVersion}		= $1;
-		$opt =~ /^a\s+(8|15|16|24)$/go		and	$hash{bpp}				= $1;
+		$opt =~ /^a\s+(8|15|16|24|32)$/go		and	$hash{bpp}				= $1;
 		$opt eq '0'							and	$hash{attachToConsole}	= 1;
 		$opt eq 'P'							and	$hash{bitmapCaching}	= 1;
 		$opt eq 'z'							and	$hash{useCompression}	= 1;
@@ -270,11 +270,11 @@ sub _buildGUI {
 			$w{frBPP} = Gtk2::Frame -> new( 'BPP:' );
 			$w{hbox1} -> pack_start( $w{frBPP}, 1, 1, 0 );
 			$w{frBPP} -> set_shadow_type( 'GTK_SHADOW_NONE' );
-			$w{frBPP} -> set_tooltip_text( '[-a] : Sets the colour depth for the connection (8, 15, 16 or 24)' );
+			$w{frBPP} -> set_tooltip_text( '[-a] : Sets the colour depth for the connection (8, 15, 16, 24 or 32)' );
 				
 				$w{cbBPP} = Gtk2::ComboBox -> new_text;
 				$w{frBPP} -> add( $w{cbBPP} );
-				foreach my $bpp ( 8, 15, 16, 24 ) { $w{cbBPP} -> append_text( $bpp ); };
+				foreach my $bpp ( 8, 15, 16, 24, 32 ) { $w{cbBPP} -> append_text( $bpp ); };
 			
 			$w{vboxup} = Gtk2::VBox -> new( 0, 0 );
 			$w{hbox1} -> pack_start( $w{vboxup}, 0, 1, 5 );

--- a/lib/method/PACMethod_rdesktop.pm
+++ b/lib/method/PACMethod_rdesktop.pm
@@ -288,7 +288,7 @@ sub _buildGUI {
 					
 					$w{chBitmapCaching} = Gtk2::CheckButton -> new_with_label( 'Bitmap Cache' );
 					$w{hboxup} -> pack_start( $w{chBitmapCaching}, 1, 1, 0 );
-					$w{chBitmapCaching} -> set_tooltip_text( '[-P] : Enable  caching  of  bitmaps to disk (persistent bitmap caching)' );
+					$w{chBitmapCaching} -> set_tooltip_text( '[-P] : Enable caching of bitmaps to disk (persistent bitmap caching)' );
 					
 					$w{chUseCompression} = Gtk2::CheckButton -> new_with_label( 'Compression' );
 					$w{hboxup} -> pack_start( $w{chUseCompression}, 1, 1, 0 );

--- a/lib/method/PACMethod_rdesktop.pm
+++ b/lib/method/PACMethod_rdesktop.pm
@@ -42,7 +42,7 @@ use Gtk2 '-init';
 
 my %RDP_VERSION = ( 4 => 0, 5 => 1 );
 my %BPP 		= ( 8 => 0, 15 => 1, 16 => 2, 24 => 3, 32 => 4 );
-my %SOUND		= ( 'local' => 0, 'off' => 1, 'remote' => 2 );
+my %SOUND		= ( 'local' => 0, 'off' => 1, 'remote' => 2, 'local:alsa' => 3, 'local:pulseaudio' =>4 );
 
 my $RES_DIR = $RealBin . '/res';
 
@@ -82,21 +82,20 @@ sub update {
 	$$self{gui}{chAttachToConsole}		-> set_active( $$options{attachToConsole} );
 	$$self{gui}{chBitmapCaching}		-> set_active( $$options{bitmapCaching} );
 	$$self{gui}{chUseCompression}		-> set_active( $$options{useCompression} );
+	$$self{gui}{chNoGrabKbd}            -> set_active( $$options{noGrabKbd} // 0 );
 	$$self{gui}{chFullscreen}			-> set_active( $$options{fullScreen} );
 	$$self{gui}{chEmbed}				-> set_active( $$options{embed} );
-	$$self{gui}{chPercentage}			-> set_active( $$options{percent} );
 	$$self{gui}{chWidthHeight}			-> set_active( $$options{wh} );
-	$$self{gui}{spGeometry}				-> set_value( $$options{geometry} ) if $$options{percent};
 	$$self{gui}{spWidth}				-> set_value( $$options{width} // 640 );
 	$$self{gui}{spHeight}				-> set_value( $$options{height} // 480 );
-	$$self{gui}{spGeometry}				-> set_sensitive( $$options{percent} );
 	$$self{gui}{hboxWidthHeight}		-> set_sensitive( $$options{wh} );
 	$$self{gui}{entryKeyboard}			-> set_text( $$options{keyboardLocale} );
-	$$self{gui}{cbRedirSound}			-> set_active( $SOUND{ $$options{redirSound} // 'local' } );
+	$$self{gui}{cbRedirSound}			-> set_active( $SOUND{ $$options{redirSound} // 'off' } );
 	$$self{gui}{entryDomain}			-> set_text( $$options{domain} // '' );
 	$$self{gui}{cbScard}				-> set_active( $$options{scard} // 0 );
 	$$self{gui}{cbEnableSeamless}		-> set_active( $$options{seamless} // 0 );
 	$$self{gui}{entryStartupShell}		-> set_text( $$options{startupshell} // '' );
+	$$self{gui}{entryOtherOptions}		-> set_text( $$options{otherOptions} // '' );
 
 	# Destroy previuos widgets
 	$$self{gui}{vbRedirect} -> foreach( sub { $_[0] -> destroy(); } );
@@ -121,19 +120,19 @@ sub get_cfg {
 	$options{attachToConsole}	= $$self{gui}{chAttachToConsole}	-> get_active;
 	$options{bitmapCaching}		= $$self{gui}{chBitmapCaching}		-> get_active;
 	$options{useCompression}	= $$self{gui}{chUseCompression}		-> get_active;
+	$options{noGrabKbd}         = $$self{gui}{chNoGrabKbd}          -> get_active;
 	$options{fullScreen}		= $$self{gui}{chFullscreen}			-> get_active;
-	$options{geometry}			= $$self{gui}{spGeometry}			-> get_value;
-	$options{percent}			= $$self{gui}{chPercentage}			-> get_active;
 	$options{width}				= $$self{gui}{spWidth}				-> get_chars( 0, -1 );
 	$options{height}			= $$self{gui}{spHeight}				-> get_chars( 0, -1 );
 	$options{wh}				= $$self{gui}{chWidthHeight}		-> get_active;
-	$options{embed}				= ! ( $$self{gui}{chFullscreen} -> get_active || $$self{gui}{chPercentage} -> get_active || $$self{gui}{chWidthHeight} -> get_active );
+	$options{embed}				= ! ( $$self{gui}{chFullscreen} -> get_active || $$self{gui}{chWidthHeight} -> get_active );
 	$options{keyboardLocale}	= $$self{gui}{entryKeyboard}		-> get_chars( 0, -1 );
 	$options{redirSound}		= $$self{gui}{cbRedirSound}			-> get_active_text;
 	$options{domain}			= $$self{gui}{entryDomain}			-> get_chars( 0, -1 );
 	$options{scard}				= $$self{gui}{cbScard}				-> get_active;
 	$options{seamless}			= $$self{gui}{cbEnableSeamless}		-> get_active;
 	$options{startupshell}		= $$self{gui}{entryStartupShell}	-> get_chars( 0, -1 );
+	$options{otherOptions}		= $$self{gui}{entryOtherOptions}	-> get_chars( 0, -1 );
 	
 	foreach my $w ( @{ $$self{listRedir} } ) {
 		my %hash;
@@ -163,51 +162,51 @@ sub _parseCfgToOptions {
 	$hash{attachToConsole}	= 0;
 	$hash{bitmapCaching}	= 0;
 	$hash{useCompression}	= 0;
+	$hash{noGrabKbd}        = 0;
 	$hash{fullScreen}		= 0;
 	$hash{scard}			= 0;
 	$hash{embed}			= 1;
-	$hash{percent}			= 0;
-	$hash{geometry}			= 90;
 	$hash{wh}				= 0;
 	$hash{width}			= 640;
 	$hash{height}			= 480;
 	$hash{keyboardLocale}	= '';
 	$hash{redirDiskShare}	= '';
 	$hash{redirDiskPath}	= $ENV{'HOME'};
-	$hash{redirSound}		= 'local';
+	$hash{redirSound}		= 'off';
 	$hash{domain}			= '';
 	$hash{seamless}			= 0;
 	$hash{startupshell}		= '';
+	$hash{otherOptions}		= '';
 	
-	my @opts = split( /\s+-/, $cmd_line );
-	foreach my $opt ( @opts ) {
-		next unless $opt ne '';
-		$opt =~ s/\s+$//go;
-		
-		$opt =~ /^(4|5)$/go					and	$hash{RDPVersion}		= $1;
-		$opt =~ /^a\s+(8|15|16|24|32)$/go		and	$hash{bpp}				= $1;
-		$opt eq '0'							and	$hash{attachToConsole}	= 1;
-		$opt eq 'P'							and	$hash{bitmapCaching}	= 1;
-		$opt eq 'z'							and	$hash{useCompression}	= 1;
-		$opt eq 'A'							and	$hash{seamless}			= 1;
-		if ( $opt =~ /^s\s+'(.+?)'$/go )	 {	$hash{startupshell} = $1; }
-		if ( $opt eq 'f' ) {					$hash{fullScreen} = 1; $hash{percent} = 0; $hash{wh} = 0; $hash{'embed'} = 0; }
-		if ( $opt =~ /^g\s+(\d+)\%$/go ) {		$hash{geometry} = $1; $hash{percent} = 1; $hash{wh} = 0; $hash{'embed'} = 0; }
-		if ( $opt =~ /^g\s+(\d+)x(\d+)$/go ){	$hash{width} = $1; $hash{height} = $2; $hash{wh} = 1; $hash{percent} = 0; $hash{'embed'} = 0; }
-		$opt =~ /^k\s+(.+)$/go				and	$hash{keyboardLocale}	= $1;
-		$opt =~ /^r\s+sound:(.+)$/go		and	$hash{redirSound}		= $1;
-		$opt =~ /^r\s+scard$/go				and	$hash{scard}			= 1;
-		$opt =~ /^r\s+clipboard:(.+)$/go	and	$hash{clipboard}		= 1;
-		$opt =~ /^d\s+(.+)$/go				and	$hash{domain}			= $1;
-		
-		while ( $opt =~ /^r\s+disk:(.+)=\"(.+)\"/go )
-		{
-			my %redir;
-			$redir{redirDiskShare}	= $1;
-			$redir{redirDiskPath}	= $2;
-			push( @{ $hash{redirDisk} }, \%redir );
-		}
-	}
+	my @opts = ( $cmd_line =~ /-\w?\s?[^-]+/g );
+    foreach my $opt ( @opts ) {
+        next unless $opt ne '';
+        $opt =~ s/\s+$//go;
+
+        if ( $opt =~ /^-(4|5)$/go )                     { $hash{RDPVersion}         = $1; }
+        elsif ( $opt =~ /^-a\s+(8|15|16|24|32)$/go )        { $hash{bpp}                = $1; }
+        elsif ( $opt eq '-0' )                      { $hash{attachToConsole}    = 1; }
+        elsif ( $opt eq '-P' )                      { $hash{bitmapCaching}      = 1; }
+        elsif ( $opt eq '-z' )                      { $hash{useCompression}     = 1; }
+        elsif ( $opt eq '-A' )                      { $hash{seamless}           = 1; }
+		elsif ( $opt eq '-K' )      				{ $hash{noGrabKbd}      	= 1; }
+        elsif ( $opt =~ /^-s\s+(.+)$/go )               { $hash{startupshell}       = $1; }
+        elsif ( $opt eq '-f' )                      { $hash{fullScreen} = 1; $hash{wh} = 0; $hash{'embed'} = 0; }
+        elsif ( $opt =~ /^-g\s+(\d+)x(\d+)$/go )            { $hash{width} = $1; $hash{height} = $2; $hash{wh} = 1; $hash{'embed'} = 0; }
+        elsif ( $opt =~ /^-k\s+(.+)$/go )               { $hash{keyboardLocale}     = $1; }
+        elsif ( $opt =~ /^-r\s+sound:(.+)$/go )         { $hash{redirSound}         = $1; }
+        elsif ( $opt =~ /^-r\s+scard$/go )              { $hash{scard}              = 1; }
+        elsif ( $opt =~ /^-r\s+clipboard:(.+)$/go )     { $hash{clipboard}          = 1; }
+        elsif ( $opt =~ /^-d\s+(.+)$/go )               { $hash{domain}             = $1; }
+        elsif ( $opt =~ /^-r\s+disk:(.+)=\"(.+)\"$/go )
+        {
+            my %redir;
+            $redir{redirDiskShare}  = $1;
+            $redir{redirDiskPath}   = $2;
+            push( @{ $hash{redirDisk} }, \%redir );
+        }
+        else { $hash{otherOptions} .= ' ' . $opt . ' '; }
+    }
 	
 	return \%hash;
 }
@@ -224,10 +223,9 @@ sub _parseOptionsToCfg {
 	$txt .= ' -z' if $$hash{useCompression};
 	$txt .= ' -f' if $$hash{fullScreen};
 	$txt .= ' -A' if $$hash{seamless};
-	$txt .= " -s '$$hash{startupshell}'" if $$hash{startupshell} ne '';
-	if ( $$hash{percent} ) {
-		$txt .= ' -g ' . $$hash{geometry} . '%';
-	} elsif ( $$hash{wh} ) {
+	$txt .= ' -K' if $$hash{noGrabKbd};
+	$txt .= ' -s ' . $$hash{startupshell} if $$hash{startupshell} ne '';
+	if ( $$hash{wh} ) {
 		$txt .= ' -g ' . $$hash{width} . 'x' . $$hash{height};
 	}
 	$txt .= ' -k ' . $$hash{keyboardLocale} if $$hash{keyboardLocale} ne '';
@@ -237,12 +235,14 @@ sub _parseOptionsToCfg {
 	$txt .= " -d $$hash{domain}" if $$hash{domain} ne '';
 	foreach my $redir ( @{ $$hash{redirDisk} } ) { $txt .= " -r disk:$$redir{redirDiskShare}=\"$$redir{redirDiskPath}\""; }
 	
+	$txt .= ' ' . $$hash{otherOptions} if $$hash{otherOptions} ne '';
+
 	return $txt;
 }
 
 sub embed {
 	my $self = shift;
-	return ! ( $$self{gui}{chFullscreen} -> get_active || $$self{gui}{chPercentage} -> get_active || $$self{gui}{chWidthHeight} -> get_active );
+	return ! ( $$self{gui}{chFullscreen} -> get_active || $$self{gui}{chWidthHeight} -> get_active );
 }
 
 sub _buildGUI {
@@ -301,7 +301,7 @@ sub _buildGUI {
 				$w{hboxdown} = Gtk2::HBox -> new( 0, 0 );
 				$w{vboxup} -> pack_start( $w{hboxdown}, 1, 1, 0 );
 					
-					$w{chClipboard} = Gtk2::CheckButton -> new_with_label( 'Clipboard forwarding ' );
+					$w{chClipboard} = Gtk2::CheckButton -> new_with_label( 'Clipboard forwarding' );
 					$w{chClipboard} -> set_tooltip_text( '[-r clipboard:PRIMARYCLIPBOARD] : Enable clipboard forwarding' );
 					$w{hboxdown} -> pack_start( $w{chClipboard}, 0, 1, 0 );
 					
@@ -309,13 +309,32 @@ sub _buildGUI {
 					$w{cbEnableSeamless} -> set_tooltip_text( '[-A] : Enable SeamlessRDP' );
 					$w{hboxdown} -> pack_start( $w{cbEnableSeamless}, 0, 1, 0 );
 					
-					$w{lblStartupShell} = Gtk2::Label -> new( ' Startup shell:' );
-					$w{hboxdown} -> pack_start( $w{lblStartupShell}, 0, 1, 0 );
-				
-					$w{entryStartupShell} = Gtk2::Entry -> new;
-					$w{entryStartupShell} -> set_tooltip_text( "[-s 'startupshell command'] : start given startupshell/command instead of explorer" );
-					$w{hboxdown} -> pack_start( $w{entryStartupShell}, 1, 1, 0 );
-				
+					$w{chNoGrabKbd} = Gtk2::CheckButton -> new_with_label( 'Keep WM key bindings' );
+					$w{chNoGrabKbd} -> set_tooltip_text( "[-K] : keep window manager key bindings" );
+					$w{hboxdown} -> pack_start( $w{chNoGrabKbd}, 0, 1, 0 );
+
+		
+		
+		$w{hboxss} = Gtk2::HBox -> new( 0, 5 );
+		$w{vbox} -> pack_start( $w{hboxss}, 0, 1, 5 );
+			
+			$w{lblStartupShell} = Gtk2::Label -> new( 'Startup shell: ' );
+			$w{hboxss} -> pack_start( $w{lblStartupShell}, 0, 1, 0 );
+			
+			$w{entryStartupShell} = Gtk2::Entry -> new;
+			$w{entryStartupShell} -> set_tooltip_text( "[-s 'startupshell command'] : start given startupshell/command instead of explorer" );
+			$w{hboxss} -> pack_start( $w{entryStartupShell}, 1, 1, 5 );
+
+		$w{hboxoo} = Gtk2::HBox -> new( 0, 5 );
+		$w{vbox} -> pack_start( $w{hboxoo}, 0, 1, 5 );
+			
+			$w{lblOtherOptions} = Gtk2::Label -> new( 'Other options: ' );
+			$w{hboxoo} -> pack_start( $w{lblOtherOptions}, 0, 1, 0 );
+			
+			$w{entryOtherOptions} = Gtk2::Entry -> new;
+			$w{entryOtherOptions} -> set_tooltip_text( "Insert other options not implemented in Asbru (launch 'rdesktop --help' to see them all)" );
+			$w{hboxoo} -> pack_start( $w{entryOtherOptions}, 1, 1, 5 );
+		
 		$w{hbox2} = Gtk2::HBox -> new( 0, 5 );
 		$w{vbox} -> pack_start( $w{hbox2}, 0, 1, 5 );
 			
@@ -335,7 +354,7 @@ sub _buildGUI {
 					
 					$w{chEmbed} = Gtk2::RadioButton -> new_with_label( $w{chFullscreen}, 'Embed in TAB' );
 					$w{hboxfsebpc} -> pack_start( $w{chEmbed}, 1, 1, 0 );
-					$w{chEmbed} -> set_tooltip_text( 'Embed terminal window in PAC TAB, using PAC\'s GUI size' );
+					$w{chEmbed} -> set_tooltip_text( 'Embed terminal window in Asbru TAB, using Asbru\'s GUI size' );
 					
 					$w{hbox69} = Gtk2::HBox -> new( 0, 5 );
 					$w{hboxfsebpc} -> pack_start( $w{hbox69}, 1, 1, 0 );
@@ -353,17 +372,6 @@ sub _buildGUI {
 							$w{hboxWidthHeight} -> pack_start( $w{spHeight}, 0, 1, 0 );
 							$w{hboxWidthHeight} -> set_sensitive( 0 );
 					
-					$w{hboxPercentage} = Gtk2::HBox -> new( 0, 5 );
-					$w{hboxsize} -> pack_start( $w{hboxPercentage}, 0, 1, 0 );
-						
-						$w{chPercentage} = Gtk2::RadioButton -> new_with_label( $w{chFullscreen}, 'Screen percentage:' );
-						$w{chPercentage} -> set_tooltip_text( '[-g percentage%] : Amount of screen to use' );
-						$w{chPercentage} -> set_active( 1 );
-						$w{hboxPercentage} -> pack_start( $w{chPercentage}, 0, 1, 0 );
-						
-						$w{spGeometry} = Gtk2::HScale -> new( Gtk2::Adjustment -> new( 90, 10, 100, 1.0, 1.0, 1.0 ) );
-						$w{hboxPercentage} -> pack_start( $w{spGeometry}, 1, 1, 0 );
-			
 			$w{frKeyboard} = Gtk2::Frame -> new( 'Keyboard layout:' );
 			$w{hbox2} -> pack_start( $w{frKeyboard}, 0, 1, 0 );
 			$w{frKeyboard} -> set_tooltip_text( '[-k] : Keyboard layout' );
@@ -381,7 +389,7 @@ sub _buildGUI {
 			$w{hboxDomain} -> pack_start( Gtk2::Label -> new( 'Sound redirect: ' ), 0, 1, 0 );
 			$w{cbRedirSound} = Gtk2::ComboBox -> new_text;
 			$w{hboxDomain} -> pack_start( $w{cbRedirSound}, 1, 1, 0 );
-			foreach my $sound ( 'local', 'off', 'remote' ) { $w{cbRedirSound} -> append_text( $sound ); };
+			foreach my $sound ( 'local', 'off', 'remote', 'local:alsa', 'local:pulseaudio' ) { $w{cbRedirSound} -> append_text( $sound ); };
 		
 		$w{frameRedirDisk} = Gtk2::Frame -> new( ' Disk redirects: ' );
 		$w{vbox} -> pack_start( $w{frameRedirDisk}, 1, 1, 0 );
@@ -409,10 +417,9 @@ sub _buildGUI {
 						$w{vp} -> add( $w{vbRedirect} );
 	
 	# Capture 'Full Screen' checkbox toggled state
-	$w{chFullscreen}	-> signal_connect( 'toggled' => sub { $w{hboxWidthHeight} -> set_sensitive( $w{chWidthHeight} -> get_active ); $w{spGeometry} -> set_sensitive( ! $w{chFullscreen} -> get_active && ! $w{chEmbed} -> get_active ); } );
-	$w{chEmbed}			-> signal_connect( 'toggled' => sub { $w{hboxWidthHeight} -> set_sensitive( $w{chWidthHeight} -> get_active ); $w{spGeometry} -> set_sensitive( ! $w{chFullscreen} -> get_active && ! $w{chEmbed} -> get_active ); } );
-	$w{chPercentage}	-> signal_connect( 'toggled' => sub { $w{hboxWidthHeight} -> set_sensitive( $w{chWidthHeight} -> get_active ); $w{spGeometry} -> set_sensitive( ! $w{chFullscreen} -> get_active && ! $w{chEmbed} -> get_active ); } );
-	$w{chWidthHeight}	-> signal_connect( 'toggled' => sub { $w{hboxWidthHeight} -> set_sensitive( $w{chWidthHeight} -> get_active ); $w{spGeometry} -> set_sensitive( ! $w{chFullscreen} -> get_active && ! $w{chEmbed} -> get_active ); } );
+	$w{chFullscreen}	-> signal_connect( 'toggled' => sub { $w{hboxWidthHeight} -> set_sensitive( $w{chWidthHeight} -> get_active ); } );
+	$w{chEmbed}			-> signal_connect( 'toggled' => sub { $w{hboxWidthHeight} -> set_sensitive( $w{chWidthHeight} -> get_active ); } );
+	$w{chWidthHeight}	-> signal_connect( 'toggled' => sub { $w{hboxWidthHeight} -> set_sensitive( $w{chWidthHeight} -> get_active ); } );
 	
 	$$self{gui} = \%w;
 	

--- a/lib/method/PACMethod_xfreerdp.pm
+++ b/lib/method/PACMethod_xfreerdp.pm
@@ -96,6 +96,7 @@ sub update {
 	$$self{gui}{chNoFastPath}			-> set_active( $$options{nofastPath} // 0 );
 	$$self{gui}{chRFX}					-> set_active( $$options{rfx} // 0 );
 	$$self{gui}{chNSCodec}				-> set_active( $$options{nsCodec} // 0 );
+	$$self{gui}{chDynamicResolution}		-> set_active( $$options{dynamicResolution} // 0 );
 	$$self{gui}{chNoRDP}				-> set_active( $$options{noRDP} // 0 );
 	$$self{gui}{chNoTLS}				-> set_active( $$options{noTLS} // 0 );
 	$$self{gui}{chNoNLA}				-> set_active( $$options{noNLA} // 0 );
@@ -139,6 +140,7 @@ sub get_cfg {
 	$options{nofastPath}        = $$self{gui}{chNoFastPath}			-> get_active;
 	$options{rfx}               = $$self{gui}{chRFX}				-> get_active;
 	$options{nsCodec}           = $$self{gui}{chNSCodec}			-> get_active;
+	$options{dynamicResolution}           = $$self{gui}{chDynamicResolution}			-> get_active;
 	$options{noRDP}             = $$self{gui}{chNoRDP}				-> get_active;
 	$options{noTLS}             = $$self{gui}{chNoTLS}				-> get_active;
 	$options{noNLA}             = $$self{gui}{chNoNLA}				-> get_active;
@@ -189,6 +191,7 @@ sub _parseCfgToOptions {
 	$hash{nofastPath}       = 0;
 	$hash{rfx}              = 0;
 	$hash{nsCodec}          = 0;
+	$hash{dynamicResolution}          = 0;
 	$hash{noRDP}            = 0;
 	$hash{noTLS}            = 0;
 	$hash{noNLA}            = 0;
@@ -217,6 +220,7 @@ sub _parseCfgToOptions {
 		$opt =~ /^-fast-path$/go	and	$hash{nofastPath}	= 1;
 		$opt =~ /^rfx$/go		and	$hash{rfx}		= 1;
 		$opt =~ /^nsc$/go		and	$hash{nsCodec}		= 1;
+		$opt =~ /^dynamic-resolution$/go		and	$hash{dynamicResolution}		= 1;
 		$opt =~ /^-sec-rdp$/go		and	$hash{noRDP}		= 1;
 		$opt =~ /^-sec-tls$/go		and	$hash{noTLS}		= 1;
 		$opt =~ /^-sec-nla$/go		and	$hash{noNLA}		= 1;
@@ -262,6 +266,7 @@ sub _parseOptionsToCfg {
 	$txt .= ' -fast-path' if $$hash{nofastPath};
 	$txt .= ' /rfx' if $$hash{rfx};
 	$txt .= ' /nsc' if $$hash{nsCodec};
+	$txt .= ' /dynamic-resolution' if $$hash{dynamicResolution};
 	$txt .= ' -sec-rdp' if $$hash{noRDP};
 	$txt .= ' -sec-tls' if $$hash{noTLS};
 	$txt .= ' -sec-nla' if $$hash{noNLA};
@@ -339,6 +344,10 @@ sub _buildGUI {
 			$w{hbox3} -> pack_start( $w{chNSCodec}, 0, 1, 0 );
 			$w{chNSCodec} -> set_tooltip_text( "/nsc: enable NSCodec (experimental)" );
 			
+			$w{chDynamicResolution} = Gtk2::CheckButton -> new_with_label( 'Enable dynamic resolution' );
+			$w{hbox3} -> pack_start( $w{chDynamicResolution}, 0, 1, 0 );
+			$w{chDynamicResolution} -> set_tooltip_text( "/dynamic-resolution: Send resolution updates when the window is resized)" );
+			
 		$w{hbox4} = Gtk2::HBox -> new( 0, 5 );
 		$w{vbox} -> pack_start( $w{hbox4}, 0, 1, 5 );
 			
@@ -386,7 +395,7 @@ sub _buildGUI {
 					$w{chEmbed} -> set_tooltip_text( "[-X:xid] : Embed RDP window in a PAC TAB\n*WARNING*: this may not work on your system with 'xfreerdp'.\nTry to select another option if your connections does not work correctly" );
 					$w{chEmbed} -> set_sensitive( 1 );
 					$w{chEmbed} -> set_active( 0 );
-					
+				
 					$w{hbox69} = Gtk2::HBox -> new( 0, 5 );
 					$w{hboxfsebpc} -> pack_start( $w{hbox69}, 1, 1, 0 );
 						

--- a/lib/method/PACMethod_xfreerdp.pm
+++ b/lib/method/PACMethod_xfreerdp.pm
@@ -443,6 +443,7 @@ sub _buildGUI {
 			$w{frKeyboard} -> set_tooltip_text( '[/kbd] : Keyboard layout' );
 				
 				$w{entryKeyboard} = Gtk2::Entry -> new;
+				$w{entryKeyboard} -> set_tooltip_text( "List keyboard layouts launching 'xfreerdp /kbd-list' (0x00000...)" );
 				$w{frKeyboard} -> add( $w{entryKeyboard} );
 		
 		$w{hboxDomain} = Gtk2::HBox -> new( 0, 5 );

--- a/lib/method/PACMethod_xfreerdp.pm
+++ b/lib/method/PACMethod_xfreerdp.pm
@@ -257,7 +257,7 @@ sub _parseOptionsToCfg {
 		$txt .= ' /size:' . $$hash{width} . 'x' . $$hash{height};
 	}
 	$txt .= ' /kbd:' . $$hash{keyboardLocale} if $$hash{keyboardLocale} ne '';
-	$txt .= ' /shell ' . $$hash{startupshell} if $$hash{startupshell} ne '';
+	$txt .= ' /shell:' . $$hash{startupshell} if $$hash{startupshell} ne '';
 	$txt .= ' /d:' . $$hash{domain} if $$hash{domain} ne '';
 	$txt .= ' +clipboard' if $$hash{redirClipboard};
         $txt .= ' /sound:sys:alsa' if $$hash{redirSound};
@@ -370,7 +370,7 @@ sub _buildGUI {
 			$w{hboxss} -> pack_start( $w{lblStartupShell}, 0, 1, 0 );
 			
 			$w{entryStartupShell} = Gtk2::Entry -> new;
-			$w{entryStartupShell} -> set_tooltip_text( "[/shell 'startupshell command'] : start given startupshell/command instead of explorer" );
+			$w{entryStartupShell} -> set_tooltip_text( "[/shell:'startupshell command'] : start given startupshell/command instead of explorer" );
 			$w{hboxss} -> pack_start( $w{entryStartupShell}, 1, 1, 5 );
 		
 		$w{hbox2} = Gtk2::HBox -> new( 0, 5 );

--- a/lib/method/PACMethod_xfreerdp.pm
+++ b/lib/method/PACMethod_xfreerdp.pm
@@ -392,7 +392,7 @@ sub _buildGUI {
 					
 					$w{chEmbed} = Gtk2::RadioButton -> new_with_label( $w{chFullscreen}, 'Embed in TAB(*)' );
 					$w{hboxfsebpc} -> pack_start( $w{chEmbed}, 1, 1, 0 );
-					$w{chEmbed} -> set_tooltip_text( "[-X:xid] : Embed RDP window in a PAC TAB\n*WARNING*: this may not work on your system with 'xfreerdp'.\nTry to select another option if your connections does not work correctly" );
+					$w{chEmbed} -> set_tooltip_text( "[-X:xid] : Embed RDP window in an Asbru TAB\n*WARNING*: if embedded windows doesn't fit perfect install Perl module X11::GUITest" );
 					$w{chEmbed} -> set_sensitive( 1 );
 					$w{chEmbed} -> set_active( 0 );
 				

--- a/lib/method/PACMethod_xfreerdp.pm
+++ b/lib/method/PACMethod_xfreerdp.pm
@@ -207,7 +207,7 @@ sub _parseCfgToOptions {
 		$opt =~ /^bpp:(8|15|16|24)$/go	  and	$hash{bpp}				= $1;
 		$opt eq 'admin'	                  and	$hash{attachToConsole}	= 1;
 		$opt eq '+compression'		  and	$hash{useCompression}	= 1;
-		if ( $opt =~ /^shell\s+'(.+?)'$/go )  {	$hash{startupshell} = $1; }
+		if ( $opt =~ /^shell:(.+)$/go )  {	$hash{startupshell} = $1; }
 		if ( $opt eq 'f' )                    {	$hash{fullScreen} = 1; $hash{percent} = 0; $hash{wh} = 0; $hash{'embed'} = 0; }
 		if ( $opt =~ /^size:(\d+)\%$/go )     {	$hash{geometry} = $1; $hash{percent} = 1; $hash{wh} = 0; $hash{'embed'} = 0; }
 		if ( $opt =~ /^size:(\d+)x(\d+)$/go ) {	$hash{width} = $1; $hash{height} = $2; $hash{wh} = 1; $hash{percent} = 0; $hash{'embed'} = 0; }

--- a/lib/method/PACMethod_xfreerdp.pm
+++ b/lib/method/PACMethod_xfreerdp.pm
@@ -103,6 +103,7 @@ sub update {
 	$$self{gui}{chFontSmooth}			-> set_active( $$options{fontSmooth} // 0 );
 	$$self{gui}{chNoGrabKbd}			-> set_active( $$options{noGrabKbd} // 0 );
 	$$self{gui}{entryStartupShell}		-> set_text( $$options{startupshell} // '' );
+	$$self{gui}{entryOtherOptions}		-> set_text( $$options{otherOptions} // '' );
 
 	# Destroy previuos widgets
 	$$self{gui}{vbRedirect} -> foreach( sub { $_[0] -> destroy(); } );
@@ -147,6 +148,7 @@ sub get_cfg {
 	$options{fontSmooth}		= $$self{gui}{chFontSmooth}			-> get_active;
 	$options{noGrabKbd}		= $$self{gui}{chNoGrabKbd}			-> get_active;
 	$options{startupshell}		= $$self{gui}{entryStartupShell}	-> get_chars( 0, -1 );
+	$options{otherOptions}		= $$self{gui}{entryOtherOptions}	-> get_chars( 0, -1 );
 
 	foreach my $w ( @{ $$self{listRedir} } ) {
 		my %hash;
@@ -186,54 +188,55 @@ sub _parseCfgToOptions {
 	$hash{redirSound}		= 0;
 	$hash{redirClipboard}	= 0;
 	$hash{domain}			= '';
-	$hash{ignoreCert}       = 0;
-	$hash{noAuth}           = 0;
-	$hash{nofastPath}       = 0;
-	$hash{rfx}              = 0;
-	$hash{nsCodec}          = 0;
-	$hash{dynamicResolution}          = 0;
-	$hash{noRDP}            = 0;
-	$hash{noTLS}            = 0;
-	$hash{noNLA}            = 0;
+	$hash{ignoreCert}	= 0;
+	$hash{noAuth}		= 0;
+	$hash{nofastPath}	= 0;
+	$hash{rfx}		= 0;
+	$hash{nsCodec}		= 0;
+	$hash{dynamicResolution}	= 0;
+	$hash{noRDP}		= 0;
+	$hash{noTLS}		= 0;
+	$hash{noNLA}		= 0;
 	$hash{fontSmooth}		= 0;
-        $hash{noGrabKbd}                = 0;
+        $hash{noGrabKbd}		= 0;
 	$hash{startupshell}		= '';
+	$hash{otherOptions}		= '';
 	
-	my @opts = split( /\s+\/?/, $cmd_line );
+	my @opts = split( / /, $cmd_line );
 	foreach my $opt ( @opts ) {
 		next unless $opt ne '';
 		$opt =~ s/\s+$//go;
 		
-		$opt =~ /^bpp:(8|15|16|24)$/go	  and	$hash{bpp}				= $1;
-		$opt eq 'admin'	                  and	$hash{attachToConsole}	= 1;
-		$opt eq '+compression'		  and	$hash{useCompression}	= 1;
-		if ( $opt =~ /^shell:(.+)$/go )  {	$hash{startupshell} = $1; }
-		if ( $opt eq 'f' )                    {	$hash{fullScreen} = 1; $hash{percent} = 0; $hash{wh} = 0; $hash{'embed'} = 0; }
-		if ( $opt =~ /^size:(\d+)\%$/go )     {	$hash{geometry} = $1; $hash{percent} = 1; $hash{wh} = 0; $hash{'embed'} = 0; }
-		if ( $opt =~ /^size:(\d+)x(\d+)$/go ) {	$hash{width} = $1; $hash{height} = $2; $hash{wh} = 1; $hash{percent} = 0; $hash{'embed'} = 0; }
-		$opt =~ /^kbd:(.+)$/go		and	$hash{keyboardLocale}	= $1;
-		$opt =~ /^sound:sys:alsa$/go	and	$hash{redirSound}	= 1;
-		$opt =~ /^\+clipboard$/go	and	$hash{redirClipboard}	= 1;
-		$opt =~ /^d:(.+)$/go		and	$hash{domain}		= $1;
-		$opt =~ /^cert-ignore$/go	and	$hash{ignoreCert}	= 1;
-		$opt =~ /^-authentication$/go	and	$hash{noAuth}		= 1;
-		$opt =~ /^-fast-path$/go	and	$hash{nofastPath}	= 1;
-		$opt =~ /^rfx$/go		and	$hash{rfx}		= 1;
-		$opt =~ /^nsc$/go		and	$hash{nsCodec}		= 1;
-		$opt =~ /^dynamic-resolution$/go		and	$hash{dynamicResolution}		= 1;
-		$opt =~ /^-sec-rdp$/go		and	$hash{noRDP}		= 1;
-		$opt =~ /^-sec-tls$/go		and	$hash{noTLS}		= 1;
-		$opt =~ /^-sec-nla$/go		and	$hash{noNLA}		= 1;
-		$opt =~ /^\+fonts$/go		and	$hash{fontSmooth}	= 1;
-		$opt =~ /^-grab-keyboard$/go	and	$hash{noGrabKbd}	= 1;
-		
-		while ( $opt =~ /^drive:(.+),(.+)/go )
+		if ( $opt =~ /^\/bpp:(8|15|16|24|32)$/go )	{ $hash{bpp}	= $1; }
+		elsif ( $opt eq '/admin' )	{ $hash{attachToConsole}	= 1; }
+		elsif ( $opt eq '+compression' )	{ $hash{useCompression}	= 1; }
+		elsif ( $opt =~ /^\/shell:(.+)$/go )	{ $hash{startupshell} = $1; }
+		elsif ( $opt eq '/f' )		{ $hash{fullScreen} = 1; $hash{percent} = 0; $hash{wh} = 0; $hash{'embed'} = 0; }
+		elsif ( $opt =~ /^\/size:(\d+)\%$/go )	{ $hash{geometry} = $1; $hash{percent} = 1; $hash{wh} = 0; $hash{'embed'} = 0; }
+		elsif ( $opt =~ /^\/size:(\d+)x(\d+)$/go )	{ $hash{width} = $1; $hash{height} = $2; $hash{wh} = 1; $hash{percent} = 0; $hash{'embed'} = 0; }
+		elsif ( $opt =~ /^\/kbd:(.+)$/go )	{ $hash{keyboardLocale}	= $1; }
+		elsif ( $opt =~ /^\/sound:sys:alsa$/go )	{ $hash{redirSound}	= 1; }
+		elsif ( $opt eq '+clipboard' )	{ $hash{redirClipboard}	= 1; }
+		elsif ( $opt =~ /^\/d:(.+)$/go )		{ $hash{domain}		= $1; }
+		elsif ( $opt eq '/cert-ignore' )	{ $hash{ignoreCert}	= 1; }
+		elsif ( $opt =~ /^-authentication$/go )	{ $hash{noAuth}		= 1; } 
+		elsif ( $opt eq '-fast-path' )	{ $hash{nofastPath}	= 1; }
+		elsif ( $opt eq '/rfx' )	{ $hash{rfx}		= 1; }
+		elsif ( $opt eq '/nsc' )	{ $hash{nsCodec}		= 1; }
+		elsif ( $opt eq '/dynamic-resolution' )	{ $hash{dynamicResolution}		= 1; }
+		elsif ( $opt eq '-sec-rdp' )	{ $hash{noRDP}		= 1; }
+		elsif ( $opt eq '-sec-tls' )	{ $hash{noTLS}		= 1; }
+		elsif ( $opt eq '-sec-nla' )	{ $hash{noNLA}		= 1; }
+		elsif ( $opt eq '+fonts' )	{ $hash{fontSmooth}	= 1; }
+		elsif ( $opt eq '-grab-keyboard' )	{ $hash{noGrabKbd}	= 1; }
+		elsif ( $opt =~ /^\/drive:(.+),(.+)$/g )
 		{
 			my %redir;
-			$redir{redirDiskShare}	= $1;
-			$redir{redirDiskPath}	= $2;
+			$redir{redirDiskShare} = $1;
+			$redir{redirDiskPath} = $2;
 			push( @{ $hash{redirDisk} }, \%redir );
 		}
+		else { $hash{otherOptions}	.= ' ' . $opt; }
 	}
 	
 	return \%hash;
@@ -274,6 +277,8 @@ sub _parseOptionsToCfg {
 	$txt .= ' -grab-keyboard' if $$hash{noGrabKbd};
 	
 	foreach my $redir ( @{ $$hash{redirDisk} } ) { $txt .= " /drive:$$redir{redirDiskShare},$$redir{redirDiskPath}"; }
+	
+	$txt .= ' ' . $$hash{otherOptions} if $$hash{otherOptions} ne '';
 	
 	return $txt;
 }
@@ -372,6 +377,16 @@ sub _buildGUI {
 			$w{entryStartupShell} = Gtk2::Entry -> new;
 			$w{entryStartupShell} -> set_tooltip_text( "[/shell:'startupshell command'] : start given startupshell/command instead of explorer" );
 			$w{hboxss} -> pack_start( $w{entryStartupShell}, 1, 1, 5 );
+		
+		$w{hboxoo} = Gtk2::HBox -> new( 0, 5 );
+		$w{vbox} -> pack_start( $w{hboxoo}, 0, 1, 5 );
+			
+			$w{lblOtherOptions} = Gtk2::Label -> new( 'Other options: ' );
+			$w{hboxoo} -> pack_start( $w{lblOtherOptions}, 0, 1, 0 );
+			
+			$w{entryOtherOptions} = Gtk2::Entry -> new;
+			$w{entryOtherOptions} -> set_tooltip_text( "Insert other options not implemented in Asbru (launch 'xfreerdp --help' to see them all)" );
+			$w{hboxoo} -> pack_start( $w{entryOtherOptions}, 1, 1, 5 );
 		
 		$w{hbox2} = Gtk2::HBox -> new( 0, 5 );
 		$w{vbox} -> pack_start( $w{hbox2}, 0, 1, 5 );

--- a/lib/method/PACMethod_xfreerdp.pm
+++ b/lib/method/PACMethod_xfreerdp.pm
@@ -40,7 +40,7 @@ use Gtk2 '-init';
 ###################################################################
 # Define GLOBAL CLASS variables
 
-my %BPP 		= ( 8 => 0, 15 => 1, 16 => 2, 24 => 3 );
+my %BPP 		= ( 8 => 0, 15 => 1, 16 => 2, 24 => 3, 32 => 4 );
 
 my $RES_DIR = $RealBin . '/res';
 
@@ -75,7 +75,7 @@ sub update {
 	
 	my $options = _parseCfgToOptions( $$self{cfg});
 	
-	$$self{gui}{cbBPP}					-> set_active( $BPP{ $$options{bpp} // 8 } );
+	$$self{gui}{cbBPP}					-> set_active( $BPP{ $$options{bpp} // 24 } );
 	$$self{gui}{chAttachToConsole}		-> set_active( $$options{attachToConsole} );
 	$$self{gui}{chUseCompression}		-> set_active( $$options{useCompression} );
 	$$self{gui}{chFullscreen}			-> set_active( $$options{fullScreen} );
@@ -170,7 +170,7 @@ sub _parseCfgToOptions {
 	my $cmd_line = shift;
 	
 	my %hash;
-	$hash{bpp}				= 8;
+	$hash{bpp}				= 24;
 	$hash{attachToConsole}	= 0;
 	$hash{useCompression}	= 0;
 	$hash{fullScreen}		= 0;
@@ -299,11 +299,11 @@ sub _buildGUI {
 			$w{frBPP} = Gtk2::Frame -> new( 'BPP:' );
 			$w{hbox1} -> pack_start( $w{frBPP}, 0, 1, 0 );
 			$w{frBPP} -> set_shadow_type( 'GTK_SHADOW_NONE' );
-			$w{frBPP} -> set_tooltip_text( '[/bpp:] : Sets the colour depth for the connection (8, 15, 16 or 24)' );
+			$w{frBPP} -> set_tooltip_text( '[/bpp:] : Sets the colour depth for the connection (8, 15, 16, 24 or 32)' );
 				
 				$w{cbBPP} = Gtk2::ComboBox -> new_text;
 				$w{frBPP} -> add( $w{cbBPP} );
-				foreach my $bpp ( 8, 15, 16, 24 ) { $w{cbBPP} -> append_text( $bpp ); };
+				foreach my $bpp ( 8, 15, 16, 24, 32 ) { $w{cbBPP} -> append_text( $bpp ); };
 			
 			$w{chAttachToConsole} = Gtk2::CheckButton -> new_with_label( 'Attach to console' );
 			$w{hbox1} -> pack_start( $w{chAttachToConsole}, 0, 1, 0 );

--- a/lib/method/PACMethod_xfreerdp.pm
+++ b/lib/method/PACMethod_xfreerdp.pm
@@ -212,7 +212,7 @@ sub _parseCfgToOptions {
 		elsif ( $opt eq '+compression' )	{ $hash{useCompression}	= 1; }
 		elsif ( $opt =~ /^\/shell:(.+)$/go )	{ $hash{startupshell} = $1; }
 		elsif ( $opt eq '/f' )		{ $hash{fullScreen} = 1; $hash{percent} = 0; $hash{wh} = 0; $hash{'embed'} = 0; }
-		elsif ( $opt =~ /^\/size:(\d+)\%$/go )	{ $hash{geometry} = $1; $hash{percent} = 1; $hash{wh} = 0; $hash{'embed'} = 0; }
+		elsif ( $opt =~ /^\/size:(\d+(\.\d+)?)%$/go )	{ $hash{geometry} = $1; $hash{percent} = 1; $hash{wh} = 0; $hash{'embed'} = 0; }
 		elsif ( $opt =~ /^\/size:(\d+)x(\d+)$/go )	{ $hash{width} = $1; $hash{height} = $2; $hash{wh} = 1; $hash{percent} = 0; $hash{'embed'} = 0; }
 		elsif ( $opt =~ /^\/kbd:(.+)$/go )	{ $hash{keyboardLocale}	= $1; }
 		elsif ( $opt =~ /^\/sound:sys:alsa$/go )	{ $hash{redirSound}	= 1; }

--- a/lib/pac_conn
+++ b/lib/pac_conn
@@ -955,7 +955,7 @@ if ( defined $METHOD ) {
 		if ( ( defined $$CFG{'tmp'}{'xid'} ) && ( $METHOD eq 'rdesktop' ) ) {
 			if ( $module_guitest eq 'Y' ) {
 				my ($xpos, $ypos, $Xwidth, $Xheight, $borderWidth, $_screen) = GetWindowPos($$CFG{'tmp'}{'xid'});
-				$$CFG{'tmp'}{'width'}  = $Xwidth;
+				$$CFG{'tmp'}{'width'}  = $Xwidth -2;
 				$$CFG{'tmp'}{'height'} = $Xheight;
 			}
 			$connection_cmd = "$METHOD -X $$CFG{'tmp'}{'xid'} -g $$CFG{'tmp'}{'width'}x$$CFG{'tmp'}{'height'} $CONNECT_OPTS" . ( $MANUAL ? '' : " -u $USER -p -" ) . " $IP:$PORT";

--- a/lib/pac_conn
+++ b/lib/pac_conn
@@ -974,6 +974,9 @@ if ( defined $METHOD ) {
 		} elsif ( $METHOD eq 'rdesktop' ) {
 			$connection_cmd = "$METHOD $CONNECT_OPTS" . ( $MANUAL ? '' : " -u $USER -p -" ) . " -T \"$TITLE\" $IP:$PORT";
 			$connection_txt = "$METHOD $CONNECT_OPTS" . ( $MANUAL ? '' : " -u $USER -p -" ) . " -T \"$TITLE\" $IP:$PORT";
+		} elsif (( $METHOD =~ /^.*freerdp$/ ) && ( defined $PASS )) {
+			$connection_cmd = "$METHOD $CONNECT_OPTS" . ( $MANUAL ? '' : " /u:$USER /p:'$PASS'" ) . " /t:\"$TITLE\" /v:$IP:$PORT";
+			$connection_txt = "$METHOD $CONNECT_OPTS" . ( $MANUAL ? '' : " /u:$USER /p:'$PASS'" ) . " /t:\"$TITLE\" /v:$IP:$PORT";
 		} elsif ( $METHOD =~ /^.*freerdp$/ ) {
 			$connection_cmd = "$METHOD $CONNECT_OPTS" . ( $MANUAL ? '' : " /u:$USER" ) . " /t:\"$TITLE\" /v:$IP:$PORT";
 			$connection_txt = "$METHOD $CONNECT_OPTS" . ( $MANUAL ? '' : " /u:$USER" ) . " /t:\"$TITLE\" /v:$IP:$PORT";

--- a/lib/pac_conn
+++ b/lib/pac_conn
@@ -769,6 +769,18 @@ sub findKP {
 	return wantarray ? @found : scalar( @found );
 }
 
+# If we want a perfect fit of an embedded RDP tab, we can use X11::GUITest if available
+# We should eval in BEGIN or perl warns "Too late to run INIT block"
+my $module_guitest;
+BEGIN{ 
+	eval("use X11::GUITest qw ( GetWindowPos GetRootWindow )");
+
+	if ($@) {
+		$module_guitest="N";
+	} else {
+		$module_guitest="Y";
+	}
+}
 # END OF : Procedures definition
 ########################################################
 
@@ -941,11 +953,22 @@ if ( defined $METHOD ) {
 	elsif	( $METHOD =~ /^.*RDP \((.+)\).*$/ ) {
 		$METHOD = $1;
 		if ( ( defined $$CFG{'tmp'}{'xid'} ) && ( $METHOD eq 'rdesktop' ) ) {
+			if ( $module_guitest eq 'Y' ) {
+				my ($xpos, $ypos, $Xwidth, $Xheight, $borderWidth, $_screen) = GetWindowPos($$CFG{'tmp'}{'xid'});
+				$$CFG{'tmp'}{'width'}  = $Xwidth;
+				$$CFG{'tmp'}{'height'} = $Xheight;
+			}
 			$connection_cmd = "$METHOD -X $$CFG{'tmp'}{'xid'} -g $$CFG{'tmp'}{'width'}x$$CFG{'tmp'}{'height'} $CONNECT_OPTS" . ( $MANUAL ? '' : " -u $USER -p -" ) . " $IP:$PORT";
 			$connection_txt = "$METHOD -X $$CFG{'tmp'}{'xid'} -g $$CFG{'tmp'}{'width'}x$$CFG{'tmp'}{'height'} $CONNECT_OPTS" . ( $MANUAL ? '' : " -u $USER -p -" ) . " $IP:$PORT";
+		} elsif ( ( defined $$CFG{'tmp'}{'xid'} ) && ( $METHOD =~ /^.*freerdp$/ ) ) {
+			if ( $module_guitest eq 'Y' ) {
+				my ($xpos, $ypos, $Xwidth, $Xheight, $borderWidth, $_screen) = GetWindowPos($$CFG{'tmp'}{'xid'});
+				$$CFG{'tmp'}{'width'}  = $Xwidth;
+				$$CFG{'tmp'}{'height'} = $Xheight;
+			}
+			$connection_cmd = "$METHOD /parent-window:$$CFG{'tmp'}{'xid'} /size:$$CFG{'tmp'}{'width'}x$$CFG{'tmp'}{'height'} $CONNECT_OPTS" . ( $MANUAL ? '' : " /u:'$USER' /p:'$PASS'" ) . " /v:$IP:$PORT";
+			$connection_txt = "$METHOD /parent-window:$$CFG{'tmp'}{'xid'} /size:$$CFG{'tmp'}{'width'}x$$CFG{'tmp'}{'height'} $CONNECT_OPTS" . ( $MANUAL ? '' : " /u:'$USER' /p:'$PASS'" ) . " /v:$IP:$PORT";
 		} elsif ( defined $$CFG{'tmp'}{'xid'} ) {
-			$$CFG{'tmp'}{'width'}-=5;
-			$$CFG{'tmp'}{'height'}-=5;
 			$connection_cmd = "$METHOD /parent-window:$$CFG{'tmp'}{'xid'} /size:$$CFG{'tmp'}{'width'}x$$CFG{'tmp'}{'height'} $CONNECT_OPTS" . ( $MANUAL ? '' : " /u:'$USER' /p:'$PASS'" ) . " /v:$IP:$PORT";
 			$connection_txt = "$METHOD /parent-window:$$CFG{'tmp'}{'xid'} /size:$$CFG{'tmp'}{'width'}x$$CFG{'tmp'}{'height'} $CONNECT_OPTS" . ( $MANUAL ? '' : " /u:'$USER' /p:'$PASS'" ) . " /v:$IP:$PORT";
 		} elsif ( $METHOD eq 'rdesktop' ) {


### PR DESCRIPTION
This PR will merge my latest patches on RDP methods. Quick changelog:

- Both methods have now a new free text box to add any option not implemented in Ásbrú
- Fixed rdesktop width size when X11:GUITest is used (it adds 2 pixels in width, don't know why)
- Added "-K: keep window manager key bindings" as a new button in rdesktop (very useful)
- Removed rdesktop percent size, it's no longer supported upstream, so I left only: fullscreen, embed and fixed size
- Fixed some typos and improved some tooltips
- Fixed percent size in xfreerdp, regex was wrong

As always, feel free to comment and request any explanations you need... I will be on vacation a couple of weeks, so maybe if a Perl guru is reading this can review and improve the code. I tried to be correct and think as simple as I can to implement the sub _parseCfgToOptions. This function now is a big "if/else" because I need to capture all parameters in one hand, and in another hand the rest of the options (those that comes from the Other Options text box). Specially in rdesktop, regex was tricky to find, because you need to catch individual options (such as -f -z) and options with one argument (such as -a 32, or -r clipboard:CLIPBOARD).