### PR TITLE
fix copy with mouse selection gets lost sometimes

### DIFF
--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -1225,7 +1225,9 @@ sub _setupCallbacks {
     # Capture mouse selection on VTE
     $$self{_GUI}{_VTE}->signal_connect('selection_changed' => sub {
         if ($$self{_CFG}{defaults}{'selection to clipboard'}) {
-            $$self{_GUI}{_VTE}->copy_clipboard;
+            if ($$self{_GUI}{_VTE}->get_has_selection) {
+                $$self{_GUI}{_VTE}->copy_clipboard;
+            }
         }
         return 0;
     });


### PR DESCRIPTION
Fix annoying bug where clipboard gets lost after copy using the mouse selection on terminal

The problem is the function gets called when text is selected and deselected, if you select text and keep it selected, you can shift insert. But if the focus on the selected text gets lost, then the clipboard gets a blank text and you loose your clipboard data.

Now the clipboard is persistent as long as no new selection is made.