### PR TITLE
Fix regression

### DIFF
--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -3525,7 +3525,13 @@ sub _updateGUIWithUUID {
 
 ”);
     } else {
-        $$self{_GUI}{descBuffer}->set_text("Connection to $$self{_CFG}{'environments'}{$uuid}{'title'}");
+        my $msg;
+        if (defined $$self{_CFG}{'environments'}{$uuid}{'title'} && $$self{_CFG}{'environments'}{$uuid}{'title'}) {
+            $msg = "Connection to $$self{_CFG}{'environments'}{$uuid}{'title'}";
+        } else {
+            $msg = $$self{_CFG}{'environments'}{$uuid}{'description'};
+        }
+        $$self{_GUI}{descBuffer}->set_text($msg);
     }
 
     if ($$self{_CFG}{'defaults'}{'show statistics'}) {


### PR DESCRIPTION
Fails on group names, that do not have title property.
In groups will display the group message instead.