### PR TITLE
removed depresiated method in gtk3, fixed render problem with <>, fix…

### DIFF
--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -1034,6 +1034,9 @@ sub _setupCallbacks {
 
             my ($bx, $by) = $$self{_GUI}{$what}->convert_widget_to_bin_window_coords($x, $y);
             my ($path, $col, $cx, $cy) = $$self{_GUI}{$what}->get_path_at_pos($bx, $by);
+            if (!$path) {
+                return 0;
+            }
             my $model = $$self{_GUI}{$what}->get_model;
             my $uuid = $model->get_value($model->get_iter($path), 2);
 
@@ -1054,7 +1057,7 @@ sub _setupCallbacks {
                 }
                 ++$total_exp;
             }
-            my $string = "- <b>Name</b>: $name\n";
+            my $string = "- <b>Name</b>: @{[__($name)]}\n";
             $string .= "- <b>Method</b>: $method\n";
             $string .= "- <b>IP / port</b>: $ip / $port\n";
             $string .= "- <b>User</b>: $user";
@@ -1062,7 +1065,6 @@ sub _setupCallbacks {
                 $string .= "- With $total_exp active <b>Expects</b>";
             }
             $string = _subst($string, $$self{_CFG}, $uuid);
-            $tooltip_widget->set_icon_from_stock("pac-method-$method", 'button');
             $tooltip_widget->set_markup($string);
 
             return 1;


### PR DESCRIPTION
Fixes errors reported in merge #264 

It affects gtk3 branch

* removed depreciated method in gtk3 (set icon from stock)
* added validation of existing path, when empty is hovering over empty rows
* added markup fix to allow for characters : <> ' " to be included in names
* tested that works with utf8 names

