### PR TITLE
Add settings to resize side tree panel automatically

### DIFF
--- a/lib/PACConfig.pm
+++ b/lib/PACConfig.pm
@@ -221,6 +221,9 @@ sub _setupCallbacks {
     _($self, 'cbConnShowPass')->signal_connect('toggled' => sub {
         _($self, 'entryPassword')->set_visibility(_($self, 'cbConnShowPass')->get_active());
     });
+    _($self, 'cbCfgEnableForceTreeSize')->signal_connect('toggled' => sub {
+        _($self, 'cbCfgForceTreeSize')->set_sensitive(_($self, 'cbCfgEnableForceTreeSize')->get_active());
+    });
     _($self, 'cbCfgPreConnPingPort')->signal_connect('toggled' => sub {
         _($self, 'spCfgPingTimeout')->set_sensitive(_($self, 'cbCfgPreConnPingPort')->get_active());
     });
@@ -693,6 +696,9 @@ sub _updateGUIPreferences {
     _($self, 'cbCfgAutoAcceptKeys')->set_active($$cfg{'defaults'}{'auto accept key'});
     _($self, 'cbCfgHideOnConnect')->set_active($$cfg{'defaults'}{'hide on connect'});
     _($self, 'cbCfgForceSplitSize')->set_active($$cfg{'defaults'}{'force split tabs to 50%'});
+    _($self, 'cbCfgEnableForceTreeSize')->set_active($$cfg{'defaults'}{'enable force tree size to x pixels'});
+    _($self, 'cbCfgForceTreeSize')->set_value($$cfg{'defaults'}{'force tree size to x pixels'});
+    _($self, 'cbCfgForceTreeSize')->set_sensitive(_($self, 'cbCfgEnableForceTreeSize')->get_active());
     _($self, 'cbCfgCloseToTray')->set_active($$cfg{'defaults'}{'close to tray'});
     _($self, 'cbCfgStartMainMaximized')->set_active($$cfg{'defaults'}{'start main maximized'});
     _($self, 'cbCfgRememberSize')->set_active($$cfg{'defaults'}{'remember main size'});
@@ -939,6 +945,8 @@ sub _saveConfiguration {
     $$self{_CFG}{'defaults'}{'auto hide button bar'} = _($self, 'cbCfgButtonBarAutoHide')->get_active();
     $$self{_CFG}{'defaults'}{'hide on connect'} = _($self, 'cbCfgHideOnConnect')->get_active();
     $$self{_CFG}{'defaults'}{'force split tabs to 50%'} = _($self, 'cbCfgForceSplitSize')->get_active();
+    $$self{_CFG}{'defaults'}{'enable force tree size to x pixels'} = _($self, 'cbCfgEnableForceTreeSize')->get_active();
+    $$self{_CFG}{'defaults'}{'force tree size to x pixels'} = _($self, 'cbCfgForceTreeSize')->get_chars(0, -1);
     $$self{_CFG}{'defaults'}{'ping port before connect'} = _($self, 'cbCfgPreConnPingPort')->get_active();
     $$self{_CFG}{'defaults'}{'ping port timeout'} = _($self, 'spCfgPingTimeout')->get_chars(0, -1);
     $$self{_CFG}{'defaults'}{'start iconified'} = _($self, 'cbCfgStartIconified')->get_active();

--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -1001,6 +1001,14 @@ sub _initGUI {
     $$self{_GUI}{hpane}->set_position($$self{_GUI}{hpanepos} // -1);
     $$self{_GUI}{_vboxSearch}->hide();
 
+    if ($$self{_CFG}{'defaults'}{'enable force tree size to x pixels'}) {
+        $self->_forceHpanePosition();
+
+        $$self{_GUI}{hpane}->signal_connect('size-allocate', sub {
+            $self->_forceHpanePosition();
+        });
+    }
+
     $self->_updateGUIPreferences();
     if ($$self{_CFG}{'defaults'}{'start PAC tree on'} eq 'connections') {
         $$self{_GUI}{nbTree}->set_current_page(0);
@@ -1014,6 +1022,30 @@ sub _initGUI {
     } else {
         $$self{_GUI}{nbTree}->set_current_page(3);
         $self->_updateGUIHistory();
+    }
+
+    return 1;
+}
+
+sub _forceHpanePosition {
+    my $self = shift;
+
+    my $x = $$self{_GUI}{main}->get_allocated_width;
+
+    if ($$self{_CFG}{defaults}{'tree on right side'}) {
+        my $newpos = $x - $$self{_CFG}{'defaults'}{'force tree size to x pixels'};
+        my $oldpos = $$self{_GUI}{hpane}->get_position();
+        if ($newpos != $oldpos) {
+            #print "INFO: Change hpane position from $oldpos to $newpos\n";
+            $$self{_GUI}{hpane}->set_position($newpos);
+        }
+    } else {
+        my $newpos = $$self{_CFG}{'defaults'}{'force tree size to x pixels'};
+        my $oldpos = $$self{_GUI}{hpane}->get_position();
+        if ($newpos != $oldpos) {
+            #print "INFO: Change hpane position from $oldpos to $newpos\n";
+            $$self{_GUI}{hpane}->set_position($newpos);
+        }
     }
 
     return 1;

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -2010,6 +2010,8 @@ sub _cfgSanityCheck {
     $$cfg{'defaults'}{'auto hide button bar'}     //= 0;
     $$cfg{'defaults'}{'hide on connect'} //= 0;
     $$cfg{'defaults'}{'force split tabs to 50%'} //= 0;
+    $$cfg{'defaults'}{'enable force tree size to x pixels'} //= 0;
+    $$cfg{'defaults'}{'force tree size to x pixels'} //= 0;
     $$cfg{'defaults'}{'ping port before connect'} //= 0;
     $$cfg{'defaults'}{'ping port timeout'} //= 1;
     $$cfg{'defaults'}{'open connections in tabs'} //= 1;

--- a/res/asbru.glade
+++ b/res/asbru.glade
@@ -70,6 +70,13 @@ If not, see <http://www.gnu.org/licenses/>.
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment15">
+    <property name="lower">200</property>
+    <property name="upper">4000</property>
+    <property name="value">200</property>
+    <property name="step_increment">10</property>
+    <property name="page_increment">100</property>
+  </object>
   <object class="GtkWindow" id="windowEdit">
     <property name="can_focus">False</property>
     <property name="modal">True</property>
@@ -3633,6 +3640,50 @@ An alternative to SSH tunneling to access internal machines through gateway.</pr
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkBox" id="hbox69">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkCheckButton" id="cbCfgEnableForceTreeSize">
+                            <property name="label" translatable="yes">Force sidebar size to X pixels: </property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="cbCfgForceTreeSize">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="invisible_char">•</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="secondary_icon_activatable">False</property>
+                            <property name="adjustment">adjustment15</property>
+                            <property name="numeric">True</property>
+                            <property name="update_policy">if-valid</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkCheckButton" id="cbCfgHideOnConnect">
                         <property name="label" translatable="yes">Hide on connection</property>
                         <property name="use_action_appearance">False</property>
@@ -3645,7 +3696,7 @@ An alternative to SSH tunneling to access internal machines through gateway.</pr
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">5</property>
+                        <property name="position">6</property>
                       </packing>
                     </child>
                     <child>

--- a/res/pac.yml
+++ b/res/pac.yml
@@ -13,6 +13,8 @@ defaults:
   global variables: {}
   hide on connect: ''
   force split tabs to 50%: 0
+  enable force tree size to x pixels: 0
+  force tree size to x pixels: 200
   intro reconnects: ''
   minimize to tray: ''
   new data color: '#00008888ffff'


### PR DESCRIPTION
Hi all,

I find really annoying that the side panel (with the connections tree) changes size when I click on it, or when I open a terminal.
I know it's only a few pixels back and forth, but I added a listener to resize it to a fixed width I like when that happens.
Please let me know if you think this could be implemented better.

Thanks