### PR TITLE
added warning unable to open session log

### DIFF
--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -1148,6 +1148,8 @@ if ($GETCMD) {
 if (open(TEST,">",$LOG_FILE)) {
     close TEST;
     $EXP->log_file($LOG_FILE);
+} else {
+    print "\n$COLOR{'err'}ERROR: could not open log file :$LOG_FILE$COLOR{'norm'}\n(check path and permissions)\n\n";
 }
 
 # Spawn the session


### PR DESCRIPTION
Add a warning when logs can not be opened so user can check settings and directory permissions

![imagen](https://user-images.githubusercontent.com/1572396/79587300-f6f6ae00-8097-11ea-89bf-0dd567a726aa.png)

Fix #569
