### PR TITLE
Fix #581 redesigned statistics to avoid jumps

### DIFF
--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -468,6 +468,7 @@ sub _initGUI {
     $$self{_GUI}{main}->add($$self{_GUI}{vbox1});
 
     $$self{_GUI}{hpane} = Gtk3::HPaned->new();
+    $$self{_GUI}{hpane}->set_wide_handle(1);
     $$self{_GUI}{vbox1}->add($$self{_GUI}{hpane});
 
     # Create a vbox3: actions, connections and other tools
@@ -818,6 +819,8 @@ sub _initGUI {
     $$self{_GUI}{scrollDescription} = Gtk3::ScrolledWindow->new();
     $$self{_GUI}{vboxInfo}->pack_start($$self{_GUI}{scrollDescription}, 1, 1, 0);
     $$self{_GUI}{scrollDescription}->set_policy('automatic', 'automatic');
+    $$self{_GUI}{scrollDescription}->set_shadow_type('GTK_SHADOW_IN');
+    $$self{_GUI}{scrollDescription}->set_border_width(5);
 
     # Create descView as a gtktextview with descBuffer
     $$self{_GUI}{descBuffer} = Gtk3::TextBuffer->new();
@@ -830,24 +833,25 @@ sub _initGUI {
     $$self{_GUI}{descView}->modify_font(Pango::FontDescription::from_string('monospace'));
 
     # Create a frameStatistics for statistics
-    $$self{_GUI}{frameStatistics} = Gtk3::Frame->new(' STATISTICS: ');
+    $$self{_GUI}{frameStatistics} = Gtk3::Frame->new('STATISTICS ');
     $$self{_GUI}{vboxInfo}->pack_start($$self{_GUI}{frameStatistics}, 0, 1, 0);
     $$self{_GUI}{frameStatistics}->set_border_width(5);
+    $$self{_GUI}{frameStatistics}->set_shadow_type('GTK_SHADOW_NONE');
 
     $$self{_GUI}{frameStatisticslbl} = Gtk3::Label->new();
-    $$self{_GUI}{frameStatisticslbl}->set_markup(' <b>STATISTICS:</b> ');
+    $$self{_GUI}{frameStatisticslbl}->set_markup('<b>STATISTICS</b> ');
     $$self{_GUI}{frameStatistics}->set_label_widget($$self{_GUI}{frameStatisticslbl});
 
     $$self{_GUI}{statistics} = $$self{_SCREENSHOTS} = PACStatistics->new();
     $$self{_GUI}{frameStatistics}->add($$self{_GUI}{statistics}->{container});
 
     # Create a frameScreenshot for screenshot
-    $$self{_GUI}{frameScreenshots} = Gtk3::Frame->new(' SCREENSHOTS: ');
+    $$self{_GUI}{frameScreenshots} = Gtk3::Frame->new('SCREENSHOTS ');
     $$self{_GUI}{vboxInfo}->pack_start($$self{_GUI}{frameScreenshots}, 0, 1, 0);
     $$self{_GUI}{frameScreenshots}->set_border_width(5);
 
     $$self{_GUI}{frameScreenshotslbl} = Gtk3::Label->new();
-    $$self{_GUI}{frameScreenshotslbl}->set_markup(' <b>SCREENSHOTS:</b> ');
+    $$self{_GUI}{frameScreenshotslbl}->set_markup('<b>SCREENSHOTS</b> ');
     $$self{_GUI}{frameScreenshots}->set_label_widget($$self{_GUI}{frameScreenshotslbl});
 
     $$self{_GUI}{screenshots} = $$self{_SCREENSHOTS} = PACScreenshots->new();

--- a/lib/PACScreenshots.pm
+++ b/lib/PACScreenshots.pm
@@ -182,10 +182,6 @@ sub _buildScreenshotsGUI {
 
     $w{bbox}->add($w{btnopenfolder});
 
-    # Build a separator
-    $w{sep} = Gtk3::VSeparator->new();
-    $w{hbox}->pack_start($w{sep}, 0, 1, 5);
-
     # Build a scrolled window
     $w{sw} = Gtk3::ScrolledWindow->new();
     $w{hbox}->pack_start($w{sw}, 1, 1, 0);

--- a/lib/PACStatistics.pm
+++ b/lib/PACStatistics.pm
@@ -69,7 +69,6 @@ sub new {
 
     $self->{cfg} = shift;
     $self->{statistics} = {};
-
     $self->{container} = undef;
     $self->{frame} = {};
 
@@ -110,12 +109,16 @@ sub update {
         my $total_time = 0;
 
         foreach my $tmpuuid (keys %{$$cfg{'environments'}}) {
-            next if $tmpuuid eq '__PAC__ROOT__';
+            if ($tmpuuid eq '__PAC__ROOT__') {
+                next;
+            }
             if ($$cfg{'environments'}{$tmpuuid}{_is_group}) {
                 $groups++;
                 $total_conn += ($$self{statistics}{$tmpuuid}{total_connections} // 0);
             } else {
-                $nodes++ unless $tmpuuid eq '__PAC_SHELL__';
+                if ($tmpuuid ne '__PAC_SHELL__') {
+                    $nodes++;
+                }
                 $total_time += ($$self{statistics}{$tmpuuid}{total_time} // 0);
                 $total_conn += ($$self{statistics}{$tmpuuid}{total_conn} // 0);
             }
@@ -123,18 +126,17 @@ sub update {
 
         # Prepare STRINGIFIED data
         my $str_total_time = '';
-        $str_total_time .= int($total_time / 86400)    . ' days, ';
-        $str_total_time .= ($total_time / 3600) % 24    . ' hours, ';
-        $str_total_time .= ($total_time / 60) % 60    . ' minutes, ';
-        $str_total_time .= $total_time % 60                . ' seconds';
+        $str_total_time .= int($total_time / 86400) . ' days, ';
+        $str_total_time .= ($total_time / 3600) % 24 . ' hours, ';
+        $str_total_time .= ($total_time / 60) % 60 . ' minutes, ';
+        $str_total_time .= $total_time % 60 . ' seconds';
 
         $$self{frame}{lblPR}->set_markup(
-            "<span $font>" .
-                "Total groups:                  <b>$groups</b>"            . "\n" .
-                "Total nodes:                   <b>$nodes</b>"            . "\n" .
-                "Total connections established: <b>$total_conn</b>"        . "\n" .
-                "Total time connected:          <b>$str_total_time</b>" .
-            "</span>"
+            "<span $font><b>All connections</b>\n" .
+            "Total groups:                  <b>$groups</b>\n" .
+            "Total nodes:                   <b>$nodes</b>\n" .
+            "Total connections established: <b>$total_conn</b>\n" .
+            "Total time connected:          <b>$str_total_time</b></span>"
         );
     } elsif ($$cfg{environments}{$uuid}{_is_group}) {
         $$self{frame}{hboxPACRoot}->hide;
@@ -159,18 +161,17 @@ sub update {
 
         # Prepare STRINGIFIED data
         my $str_total_time = '';
-        $str_total_time .= int($total_time / 86400)    . ' days, ';
-        $str_total_time .= ($total_time / 3600) % 24    . ' hours, ';
-        $str_total_time .= ($total_time / 60) % 60    . ' minutes, ';
-        $str_total_time .= $total_time % 60                . ' seconds';
+        $str_total_time .= int($total_time / 86400) . ' days, ';
+        $str_total_time .= ($total_time / 3600) % 24 . ' hours, ';
+        $str_total_time .= ($total_time / 60) % 60 . ' minutes, ';
+        $str_total_time .= $total_time % 60 . ' seconds';
 
         $$self{frame}{lblPG}->set_markup(
-            "<span $font>" .
-                "Total sub-groups:              <b>$groups</b>"            . "\n" .
-                "Total contained nodes:         <b>$nodes</b>"            . "\n" .
-                "Total connections established: <b>$total_conn</b>"        . "\n" .
-                "Total time connected:          <b>$str_total_time</b>" .
-            "</span>"
+            "<span $font><b>Group: @{[__($name)]}</b>\n" .
+            "Total sub-groups:              <b>$groups</b>\n" .
+            "Total contained nodes:         <b>$nodes</b>\n" .
+            "Total connections established: <b>$total_conn</b>\n" .
+            "Total time connected:          <b>$str_total_time</b></span>"
         );
     } else {
         $$self{frame}{hboxPACRoot}->hide;
@@ -201,23 +202,18 @@ sub update {
 
         # Prepare STRINGIFIED data
         my $str_total_time = '';
-        $str_total_time .= int($total_time / 86400)    . ' days, ';
-        $str_total_time .= ($total_time / 3600) % 24    . ' hours, ';
-        $str_total_time .= ($total_time / 60) % 60    . ' minutes, ';
-        $str_total_time .= $total_time % 60                . ' seconds';
+        $str_total_time .= int($total_time / 86400) . ' days, ';
+        $str_total_time .= ($total_time / 3600) % 24 . ' hours, ';
+        $str_total_time .= ($total_time / 60) % 60 . ' minutes, ';
+        $str_total_time .= $total_time % 60 . ' seconds';
 
         $$self{frame}{lblPN}->set_markup(
-            "<span $font>" .
-                "Total time connected:          <b>$str_total_time</b>"    . "\n" .
-                "Total connections established: <b>$total_conn</b>"        . "\n" .
-                "Last connection:               <b>$str_start</b>" .
-            "</span>"
+            "<span $font><b>Connection: @{[__($name)]}</b>\n\n" .
+            "Total connections established: <b>$total_conn</b>\n" .
+            "Last connection:               <b>$str_start</b>\n" .
+            "Total time connected:          <b>$str_total_time</b></span>"
         );
     }
-
-    if ($uuid eq '__PAC__ROOT__')                        {$$self{frame}{btnReset}->set_label("Reset Statistics for\n'all connections'...");}
-    elsif ($$cfg{'environments'}{$uuid}{_is_group})    {$$self{frame}{btnReset}->set_label("Reset statistics for group\n'$name'...");}
-    else                                                {$$self{frame}{btnReset}->set_label("Reset statistics for\n'$name'...");}
 
     return 1;
 }
@@ -278,36 +274,37 @@ sub _buildStatisticsGUI {
     # Build a vbox for:buttons, separator and image widgets
     $w{hbox} = Gtk3::HBox->new(0, 0);
 
-        $w{btnReset} = Gtk3::Button->new_with_label('Reset Statistics...');
-        $w{btnReset}->set_image(Gtk3::Image->new_from_stock('gtk-refresh', 'button') );
-        $w{btnReset}->set('can-focus', 0);
-        $w{hbox}->pack_start($w{btnReset}, 0, 1, 0);
+    $w{btnReset} = Gtk3::Button->new_with_label('Reset Statistics');
+    $w{btnReset}->set_image(Gtk3::Image->new_from_stock('gtk-refresh', 'button') );
+    $w{btnReset}->set('can-focus', 0);
+    $w{hbox}->pack_start($w{btnReset}, 0, 0, 5);
+    $w{btnReset}->set_vexpand(0);
 
-        $w{hbox}->pack_start(Gtk3::VSeparator->new, 0, 1, 5);
+    #$w{hbox}->pack_start(Gtk3::VSeparator->new, 0, 1, 5);
 
-        $w{vbox} = Gtk3::VBox->new(0, 0);
-        $w{hbox}->pack_start($w{vbox}, 1, 1, 0);
+    $w{vbox} = Gtk3::VBox->new(0, 0);
+    $w{hbox}->pack_start($w{vbox}, 1, 1, 0);
 
-            $w{hboxPACRoot} = Gtk3::HBox->new(0, 0);
-            $w{vbox}->pack_start($w{hboxPACRoot}, 0, 1, 0);
+    $w{hboxPACRoot} = Gtk3::HBox->new(0, 0);
+    $w{vbox}->pack_start($w{hboxPACRoot}, 0, 1, 0);
 
-                $w{lblPR} = Gtk3::Label->new;
-                $w{lblPR}->set_justify('left');
-                $w{hboxPACRoot}->pack_start($w{lblPR}, 0, 1, 0);
+    $w{lblPR} = Gtk3::Label->new;
+    $w{lblPR}->set_justify('left');
+    $w{hboxPACRoot}->pack_start($w{lblPR}, 0, 1, 0);
 
-            $w{hboxPACGroup} = Gtk3::HBox->new(0, 0);
-            $w{vbox}->pack_start($w{hboxPACGroup}, 0, 1, 0);
+    $w{hboxPACGroup} = Gtk3::HBox->new(0, 0);
+    $w{vbox}->pack_start($w{hboxPACGroup}, 0, 1, 0);
 
-                $w{lblPG} = Gtk3::Label->new;
-                $w{lblPG}->set_justify('left');
-                $w{hboxPACGroup}->pack_start($w{lblPG}, 0, 1, 0);
+    $w{lblPG} = Gtk3::Label->new;
+    $w{lblPG}->set_justify('left');
+    $w{hboxPACGroup}->pack_start($w{lblPG}, 0, 0, 0);
 
-            $w{hboxPACNode} = Gtk3::HBox->new(0, 0);
-            $w{vbox}->pack_start($w{hboxPACNode}, 0, 1, 0);
+    $w{hboxPACNode} = Gtk3::HBox->new(0, 0);
+    $w{vbox}->pack_start($w{hboxPACNode}, 0, 1, 0);
 
-                $w{lblPN} = Gtk3::Label->new;
-                $w{lblPN}->set_justify('left');
-                $w{hboxPACNode}->pack_start($w{lblPN}, 0, 1, 0);
+    $w{lblPN} = Gtk3::Label->new;
+    $w{lblPN}->set_justify('left');
+    $w{hboxPACNode}->pack_start($w{lblPN}, 0, 1, 0);
 
     $$self{container} = $w{hbox};
     $$self{frame} = \%w;

--- a/lib/PACStatistics.pm
+++ b/lib/PACStatistics.pm
@@ -290,6 +290,7 @@ sub _buildStatisticsGUI {
 
     $w{lblPR} = Gtk3::Label->new;
     $w{lblPR}->set_justify('left');
+    $w{lblPR}->set_line_wrap(1);
     $w{hboxPACRoot}->pack_start($w{lblPR}, 0, 1, 0);
 
     $w{hboxPACGroup} = Gtk3::HBox->new(0, 0);
@@ -297,6 +298,7 @@ sub _buildStatisticsGUI {
 
     $w{lblPG} = Gtk3::Label->new;
     $w{lblPG}->set_justify('left');
+    $w{lblPG}->set_line_wrap(1);
     $w{hboxPACGroup}->pack_start($w{lblPG}, 0, 0, 0);
 
     $w{hboxPACNode} = Gtk3::HBox->new(0, 0);
@@ -304,6 +306,7 @@ sub _buildStatisticsGUI {
 
     $w{lblPN} = Gtk3::Label->new;
     $w{lblPN}->set_justify('left');
+    $w{lblPN}->set_line_wrap(1);
     $w{hboxPACNode}->pack_start($w{lblPN}, 0, 1, 0);
 
     $$self{container} = $w{hbox};

--- a/lib/PACStatistics.pm
+++ b/lib/PACStatistics.pm
@@ -320,30 +320,33 @@ sub _buildStatisticsGUI {
         my $name = $$cfg{environments}{$uuid}{name};
 
         if ($uuid eq '__PAC__ROOT__') {
-            return 1 unless _wConfirm($PACMain::FUNCS{_MAIN}{_GUI}{main}, "Are you sure you want to reset <b>ALL PAC</b> statistics?\n(This action can not be undone!)");
-            foreach my $child (keys %{$$cfg{environments}})
-            {
-                next if $child eq '__PAC__ROOT__';
-                $$self{statistics}{$child}{start} = 0;
-                $$self{statistics}{$child}{stop} = 0;
-                $$self{statistics}{$child}{total_conn} = 0;
-                $$self{statistics}{$child}{total_time} = 0;
+            if (_wConfirm($PACMain::FUNCS{_MAIN}{_GUI}{main}, "Are you sure you want to reset <b>all Ásbrú</b> statistics?\n\nThis action can not be undone!")) {
+                foreach my $child (keys %{$$cfg{environments}}) {
+                    if ($child eq '__PAC__ROOT__') {
+                        next;
+                    }
+                    $$self{statistics}{$child}{start} = 0;
+                    $$self{statistics}{$child}{stop} = 0;
+                    $$self{statistics}{$child}{total_conn} = 0;
+                    $$self{statistics}{$child}{total_time} = 0;
+                }
             }
         } elsif ($$cfg{environments}{$uuid}{_is_group}) {
-            return 1 unless _wConfirm($PACMain::FUNCS{_MAIN}{_GUI}{main}, "Are you sure you want to reset statistics for group '<b>$name</b>'?\n(This action can not be undone!)");
-            foreach my $child ($PACMain::FUNCS{_MAIN}{_GUI}{treeConnections}->_getChildren($uuid, 0, 1) )
-            {
-                $$self{statistics}{$child}{start} = 0;
-                $$self{statistics}{$child}{stop} = 0;
-                $$self{statistics}{$child}{total_conn} = 0;
-                $$self{statistics}{$child}{total_time} = 0;
+            if (_wConfirm($PACMain::FUNCS{_MAIN}{_GUI}{main}, "Are you sure you want to reset statistics for group:\n\n<b>@{[__($name)]}</b>\n\nThis action can not be undone!")) {
+                foreach my $child ($PACMain::FUNCS{_MAIN}{_GUI}{treeConnections}->_getChildren($uuid, 0, 1)) {
+                    $$self{statistics}{$child}{start} = 0;
+                    $$self{statistics}{$child}{stop} = 0;
+                    $$self{statistics}{$child}{total_conn} = 0;
+                    $$self{statistics}{$child}{total_time} = 0;
+                }
             }
         } else {
-            return 1 unless _wConfirm($PACMain::FUNCS{_MAIN}{_GUI}{main}, "Are you sure you want to reset statistics for connection '<b>$name</b>'?\n(This action can not be undone!)");
-            $$self{statistics}{$uuid}{start} = 0;
-            $$self{statistics}{$uuid}{stop} = 0;
-            $$self{statistics}{$uuid}{total_conn} = 0;
-            $$self{statistics}{$uuid}{total_time} = 0;
+            if (_wConfirm($PACMain::FUNCS{_MAIN}{_GUI}{main}, "Are you sure you want to reset statistics for connection:\n\n<b>@{[__($name)]}</b>\n\nThis action can not be undone!")) {
+                $$self{statistics}{$uuid}{start} = 0;
+                $$self{statistics}{$uuid}{stop} = 0;
+                $$self{statistics}{$uuid}{total_conn} = 0;
+                $$self{statistics}{$uuid}{total_time} = 0;
+            }
         }
 
         $self->update($uuid);


### PR DESCRIPTION
Fix #581 

The problem happens with left or right panel position. Right panel is more affected by the bug.

The largest problem came from the renaming of the Reset statistics button.

I left the button with a fixed width. And rearranged the messages to be clearer and have the same amount of lines so it would not cause the same jumping effect, vertically if the number of lines changes .

The problem arises when the connection panel is resized to squeeze the tabs panel to its minimum. If you leave no space for the statistics time connection to grow or contract you would get a small jump. Because of the resizing of that panel.

![imagen](https://user-images.githubusercontent.com/1572396/80032249-834a0c00-84b0-11ea-8196-2ec9892e2db6.png)

The new design will stop the large changes seen in the original bug report. But I could not find a way to control the resize, or wrapping to avoided the small changes caused by the time legends. Maybe with your experience in gtk widgets, you can manage to tweak it so it controls that small resize. 

+ I tried to get that label inside a scrolled window, but then a got into a bunch of other troubles. So I dropped that road.
+ Tried to make the legend widget to overflow the text so it would not create a resize, could not do it. (this would be the best solution)
+ Tried to make the widget wrap the text. Could not do it. This would end up making the top info panel resize and make it jump.

I took the opportunity to retouch the Main window to make it cleaner by:

+ Adding a large resize handle that separates the 2 notebooks and have a cleaner view and not an group of thine vertical lines clustering all against each other.
+ Removing border frames decorations
+ Add a border separation to the info window and adding a border to stand out its limits.

![imagen](https://user-images.githubusercontent.com/1572396/80032529-e9369380-84b0-11ea-8887-48a3967923b5.png)
