### PR TITLE
set window title in detached tab

### DIFF
--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -960,7 +960,7 @@ sub _setupCallbacks {
     # Capture focus-in
     $$self{_GUI}{_VTE}->signal_connect('focus_in_event' => sub {
         if ($$self{_CFG}{defaults}{'change main title'}) {
-            $PACMain::FUNCS{_MAIN}{_GUI}{main}->set_title("@{[__($$self{_TITLE})]}  - $APPNAME");
+            $$self{_NOTEBOOKWINDOW}->set_title("@{[__($$self{_TITLE})]}  - $APPNAME");
         }
     });
 


### PR DESCRIPTION
Another bug fix for tabbed windows.

When option "change main window title with terminal name is set"

![imagen](https://user-images.githubusercontent.com/1572396/81477350-0b345380-91dd-11ea-9a44-8e144c598b05.png)

It works for the Terminal Window and main Ásbru window

![imagen](https://user-images.githubusercontent.com/1572396/81477387-33bc4d80-91dd-11ea-8544-444803a8d558.png)

But does not work for the Detached Tabs Window

![imagen](https://user-images.githubusercontent.com/1572396/81477410-52224900-91dd-11ea-97d7-3602e33b58ef.png)

This change makes it work in all 3 cases.

This could be added to 6.2



