### PR TITLE
fix change method, properties not visible

### DIFF
--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -301,6 +301,7 @@ sub _setupCallbacks {
 
         &{$$self{_METHODS}{$method}{'updateGUI'}}($$self{_CFG}{'environments'}{$$self{_UUID}});
         $$self{_SPECIFIC}->change($method, $$self{_CFG}{'environments'}{$$self{_UUID}});
+        $$self{_WINDOWEDIT}->show_all(); # Without this line, $$self{_SPECIFIC} widgets WILL NOT BE SHOWN!!!!!!!!!
         __checkRBAuth($self);
     });
 


### PR DESCRIPTION
If you edit any connection (new or existing one), and change the method, the newly selected specific method options are not visible until you close the edit window and reopen again.
