### PR TITLE
Fix603

### DIFF
--- a/lib/PACConfig.pm
+++ b/lib/PACConfig.pm
@@ -815,6 +815,7 @@ sub _updateGUIPreferences {
     _($self, 'rbOnNoTabsHide')->set_active($$cfg{'defaults'}{'when no more tabs'} == 2);
     _($self, 'cbCfgSelectionToClipboard')->set_active($$cfg{'defaults'}{'selection to clipboard'});
     _($self, 'cbCfgRemoveCtrlCharsConf')->set_active($$cfg{'defaults'}{'remove control chars'});
+    _($self, 'cbCfgLogTimestam')->set_active($$cfg{'defaults'}{'log timestamp'});
     _($self, 'cbCfgAllowMoreInstances')->set_active($$cfg{'defaults'}{'allow more instances'});
     _($self, 'cbCfgShowFavOnUnity')->set_active($$cfg{'defaults'}{'show favourites in unity'});
     _($self, 'comboLayout')->set_active($layout{$$cfg{'defaults'}{'layout'}});
@@ -1108,6 +1109,7 @@ sub _saveConfiguration {
     $$self{_CFG}{'defaults'}{'when no more tabs'} = _($self, 'rbOnNoTabsNothing')->get_active() ? 'last' : 'next';
     $$self{_CFG}{'defaults'}{'selection to clipboard'} = _($self, 'cbCfgSelectionToClipboard')->get_active();
     $$self{_CFG}{'defaults'}{'remove control chars'} = _($self, 'cbCfgRemoveCtrlCharsConf')->get_active();
+    $$self{_CFG}{'defaults'}{'log timestamp'} = _($self, 'cbCfgLogTimestam')->get_active();
     $$self{_CFG}{'defaults'}{'allow more instances'} = _($self, 'cbCfgAllowMoreInstances')->get_active();
     $$self{_CFG}{'defaults'}{'show favourites in unity'} = _($self, 'cbCfgShowFavOnUnity')->get_active();
     $$self{_CFG}{'defaults'}{'layout'} = _($self, 'comboLayout')->get_active_text();

--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -701,6 +701,7 @@ sub _updateGUIPreferences {
     _($self, 'cbAutossh')->set_active($$self{_CFG}{'environments'}{$uuid}{'autossh'} // 0);
     _($self, 'entryUUID')->set_text($uuid);
     _($self, 'cbCfgRemoveCtrlChars')->set_active($$self{_CFG}{'environments'}{$uuid}{'remove control chars'});
+    _($self, 'cbCfgLogTimestamp')->set_active($$self{_CFG}{'environments'}{$uuid}{'log timestamp'});
 
     # Populate 'comboStartScript' combobox
     _($self, 'comboStartScript')->remove_all();
@@ -877,6 +878,7 @@ sub _saveConfiguration {
     $$self{_CFG}{'environments'}{$uuid}{'startup script name'} = _($self, 'comboStartScript')->get_active_text;
     $$self{_CFG}{'environments'}{$uuid}{'autossh'} = _($self, 'cbAutossh')->get_active;
     $$self{_CFG}{'environments'}{$uuid}{'remove control chars'} = _($self, 'cbCfgRemoveCtrlChars')->get_active;
+    $$self{_CFG}{'environments'}{$uuid}{'log timestamp'} = _($self, 'cbCfgLogTimestamp')->get_active;
 
     ##################
     # Other options...

--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -1137,7 +1137,8 @@ sub _setupCallbacks {
                 $handled_by_vte = $$self{_GUI}{_VTE}->event($event);
                 $right_click_deep = 0;
             }
-            if (! $handled_by_vte) {
+            if (!$handled_by_vte) {
+                $$self{FOCUS}->child_focus('GTK_DIR_TAB_FORWARD');
                 $self->_vteMenu($event);
             }
             return 1;  # One way or another, we've handled it.

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -3320,7 +3320,7 @@ sub _removeEscapeSeqs {
     $string =~ s/\e\[[0-9;]*[a-zA-Z]%?//g;
     $string =~ s/\e\[[0-9;]*m(?:\e\[K)?//g;
     $string =~ s/\x1B\]1.+?\x07\n?//g;
-    $string =~ s/(\x1B|\x08|\x07)(\[w|=)?//g;
+    $string =~ s/(\x1B|\x08|\x07)(\[w|=|\(B)?//g;
     $string =~ s/\[\?\d+\w{1,2}//g;
     $string =~ s/\]\d;//g;
 

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -3319,7 +3319,7 @@ sub _removeEscapeSeqs {
     $string =~ s/\x1B[=>]//g;
     $string =~ s/\e\[[0-9;]*[a-zA-Z]%?//g;
     $string =~ s/\e\[[0-9;]*m(?:\e\[K)?//g;
-    $string =~ s/\x1B\]1.+?\x07//g;
+    $string =~ s/\x1B\]1.+?\x07\n?//g;
     $string =~ s/(\x1B|\x08|\x07)(\[w|=)?//g;
     $string =~ s/\[\?\d+\w{1,2}//g;
     $string =~ s/\]\d;//g;

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -3318,7 +3318,8 @@ sub _removeEscapeSeqs {
     $string =~ s/\x1B[=>]//g;
     $string =~ s/\e\[[0-9;]*[a-zA-Z]%?//g;
     $string =~ s/\e\[[0-9;]*m(?:\e\[K)?//g;
-    $string =~ s/\x1B.+?\x07//g;
+    #$string =~ s/\x1B.+?\x07//g;
+    $string =~ s/\x1B\]1.+?\x07//g;
     $string =~ s/(\x1B|\x08|\x07)(\[w|=)?//g;
     $string =~ s/\[\?\d+\w{1,2}//g;
     $string =~ s/\]\d;//g;

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -178,6 +178,7 @@ my $LOG_FILE = $$CFG{'tmp'}{'log file'};
 my $SOCK_FILE = $$CFG{'tmp'}{'socket'};
 my $SOCK_EXEC_FILE = $$CFG{'tmp'}{'socket exec'};
 my $REMOVE_CTRL_CHARS = $$CFG{'environments'}{$UUID}{'save session logs'} ? $$CFG{'environments'}{$UUID}{'remove control chars'} : $$CFG{'defaults'}{'remove control chars'};
+my $LOG_TIMESTAMP = $$CFG{'environments'}{$UUID}{'log timestamp'} ? $$CFG{'environments'}{$UUID}{'log timestamp'} : $$CFG{'defaults'}{'log timestamp'};
 my $LPORT;
 
 if (!$RESTART && $IS_CLUSTER) {
@@ -1290,7 +1291,7 @@ if ($GETCMD) {
 # Only if the target directory is writable; if not writable, we can silently ignore the erroneous log file since the warning has already been raised in the main application
 
 if (open(LOG,">:raw",$LOG_FILE)) {
-    if ($$CFG{'environments'}{$UUID}{'log timestamp'}) {
+    if ($LOG_TIMESTAMP) {
         $EXP->log_file(\&logTime);
     } else {
         close LOG;
@@ -2180,7 +2181,7 @@ exit 0;
 sub close_log_file {
     my $line;
 
-    if ($$CFG{'environments'}{$UUID}{'log timestamp'}) {
+    if ($LOG_TIMESTAMP) {
         close LOG;
     }
     if (!$LOG_FILE || !$REMOVE_CTRL_CHARS) {
@@ -2197,7 +2198,7 @@ sub close_log_file {
     }
     while ($line = <FIN>) {
         my $l = _removeEscapeSeqs($line);
-        if ($$CFG{'environments'}{$UUID}{'log timestamp'}) {
+        if ($LOG_TIMESTAMP) {
             while ($l =~ s/^(\D.+?)\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} : /$1/) {}
             if ($l !~ /^\d{3,4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} : /) {
                 print FOUT ' 'x22;

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -1021,12 +1021,9 @@ sub _hardClose {
 }
 
 sub logTime {
-    my $txt = _removeEscapeSeqs($_[0]);
     my $t = encode('utf8',strftime "%Y-%m-%d %H:%M:%S", localtime());
-    #print LOG ">$_[0]<\n";
-    #print LOG "[$txt]\n";
-    print LOG "$t : $txt";
-    if ($txt !~ /\n|\r$/) {
+    print LOG "$t : $_[0]";
+    if ($_[0] !~ /\n|\r$/) {
         print LOG "\n";
     }
 }
@@ -1293,8 +1290,12 @@ if ($GETCMD) {
 # Only if the target directory is writable; if not writable, we can silently ignore the erroneous log file since the warning has already been raised in the main application
 
 if (open(LOG,">:raw",$LOG_FILE)) {
-    #$EXP->log_file($LOG_FILE);
-    $EXP->log_file(\&logTime);
+    if ($$CFG{'environments'}{$UUID}{'log timestamp'}) {
+        $EXP->log_file(\&logTime);
+    } else {
+        close LOG;
+        $EXP->log_file($LOG_FILE);
+    }
 } else {
     print "\n$COLOR{'err'}ERROR: could not open log file :$LOG_FILE$COLOR{'norm'}\n(check path and permissions)\n\n";
 }
@@ -2179,9 +2180,9 @@ exit 0;
 sub close_log_file {
     my $line;
 
-    close LOG;
-    return 1;
-
+    if ($$CFG{'environments'}{$UUID}{'log timestamp'}) {
+        close LOG;
+    }
     if (!$LOG_FILE || !$REMOVE_CTRL_CHARS) {
         return 1;
     }
@@ -2195,7 +2196,14 @@ sub close_log_file {
         return 1;
     }
     while ($line = <FIN>) {
-        print FOUT _removeEscapeSeqs($line);
+        my $l = _removeEscapeSeqs($line);
+        if ($$CFG{'environments'}{$UUID}{'log timestamp'}) {
+            while ($l =~ s/^(\D.+?)\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} : /$1/) {}
+            if ($l !~ /^\d{3,4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} : /) {
+                print FOUT ' 'x22;
+            }
+        }
+        print FOUT $l;
     }
     close FIN;
     close FOUT;

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -2185,11 +2185,11 @@ exit 0;
 sub close_log_file {
     my $line;
 
-    if (!$LOG_FILE || !$REMOVE_CTRL_CHARS) {
-        return 1;
-    }
     if ($LOG_TIMESTAMP) {
         close LOG;
+    }
+    if (!$LOG_FILE || !$REMOVE_CTRL_CHARS) {
+        return 1;
     }
     if (!open(FIN,"<:raw",$LOG_FILE)) {
         ctrl("ERROR: Could not open file '$LOG_FILE' for reading!! ($!)");

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -2185,11 +2185,11 @@ exit 0;
 sub close_log_file {
     my $line;
 
-    if ($LOG_TIMESTAMP) {
-        close LOG;
-    }
     if (!$LOG_FILE || !$REMOVE_CTRL_CHARS) {
         return 1;
+    }
+    if ($LOG_TIMESTAMP) {
+        close LOG;
     }
     if (!open(FIN,"<:raw",$LOG_FILE)) {
         ctrl("ERROR: Could not open file '$LOG_FILE' for reading!! ($!)");

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -42,6 +42,7 @@ use IO::Socket::INET;
 use Encode;
 use PACKeePass;
 use PACUtils;
+use POSIX qw(strftime);
 
 use Gtk3 '-init';
 
@@ -1019,6 +1020,17 @@ sub _hardClose {
     return 0;
 }
 
+sub logTime {
+    my $txt = _removeEscapeSeqs($_[0]);
+    my $t = encode('utf8',strftime "%Y-%m-%d %H:%M:%S", localtime());
+    #print LOG ">$_[0]<\n";
+    #print LOG "[$txt]\n";
+    print LOG "$t : $txt";
+    if ($txt !~ /\n|\r$/) {
+        print LOG "\n";
+    }
+}
+
 # If we want a perfect fit of an embedded RDP tab, we can use X11::GUITest if available
 # We should eval in BEGIN or perl warns "Too late to run INIT block"
 my $module_guitest;
@@ -1279,9 +1291,10 @@ if ($GETCMD) {
 
 # Set log file
 # Only if the target directory is writable; if not writable, we can silently ignore the erroneous log file since the warning has already been raised in the main application
-if (open(TEST,">",$LOG_FILE)) {
-    close TEST;
-    $EXP->log_file($LOG_FILE);
+
+if (open(LOG,">:raw",$LOG_FILE)) {
+    #$EXP->log_file($LOG_FILE);
+    $EXP->log_file(\&logTime);
 } else {
     print "\n$COLOR{'err'}ERROR: could not open log file :$LOG_FILE$COLOR{'norm'}\n(check path and permissions)\n\n";
 }
@@ -2165,6 +2178,9 @@ exit 0;
 
 sub close_log_file {
     my $line;
+
+    close LOG;
+    return 1;
 
     if (!$LOG_FILE || !$REMOVE_CTRL_CHARS) {
         return 1;

--- a/res/asbru.glade
+++ b/res/asbru.glade
@@ -5768,9 +5768,91 @@ sudo -p sudo_prompt_string ...</property>
                                 <property name="can_focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_left">20</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbCfgRemoveCtrlCharsConf">
+                                        <property name="label" translatable="yes">Remove CONTROL characters. </property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbCfgLogTimestam">
+                                        <property name="label" translatable="yes">Add timestamp</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="margin_left">20</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label30">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="has_tooltip">True</property>
+                                        <property name="tooltip_text" translatable="yes">0 to keep all session logs</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes"> Files to save </property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spCfgSaveSessionLogs">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="has_tooltip">True</property>
+                                        <property name="tooltip_text" translatable="yes">0 to keep all session logs</property>
+                                        <property name="invisible_char">•</property>
+                                        <property name="text" translatable="yes">0</property>
+                                        <property name="primary_icon_activatable">False</property>
+                                        <property name="secondary_icon_activatable">False</property>
+                                        <property name="adjustment">adjustment11</property>
+                                        <property name="numeric">True</property>
+                                        <property name="update_policy">if-valid</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <object class="GtkBox" id="hboxCfgSaveSessionLogsasdf">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
+                                    <property name="margin_left">20</property>
                                     <child>
                                       <object class="GtkLabel" id="label25">
                                         <property name="visible">True</property>
@@ -5840,66 +5922,18 @@ sudo -p sudo_prompt_string ...</property>
                                         <property name="position">2</property>
                                       </packing>
                                     </child>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbCfgRemoveCtrlCharsConf">
-                                        <property name="label" translatable="yes">Remove CONTROL characters. </property>
-                                        <property name="use_action_appearance">False</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="xalign">0.5</property>
-                                        <property name="draw_indicator">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">3</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="label30">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="has_tooltip">True</property>
-                                        <property name="tooltip_text" translatable="yes">0 to keep all session logs</property>
-                                        <property name="label" translatable="yes"> Files to save </property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spCfgSaveSessionLogs">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="has_tooltip">True</property>
-                                        <property name="tooltip_text" translatable="yes">0 to keep all session logs</property>
-                                        <property name="invisible_char">•</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="adjustment">adjustment11</property>
-                                        <property name="numeric">True</property>
-                                        <property name="update_policy">if-valid</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">5</property>
-                                      </packing>
-                                    </child>
                                   </object>
                                   <packing>
                                     <property name="expand">True</property>
                                     <property name="fill">True</property>
-                                    <property name="position">0</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="hbox24">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
+                                    <property name="margin_left">20</property>
                                     <child>
                                       <object class="GtkLabel" id="lblEditLogFileName">
                                         <property name="visible">True</property>
@@ -5948,7 +5982,7 @@ sudo -p sudo_prompt_string ...</property>
                                   <packing>
                                     <property name="expand">True</property>
                                     <property name="fill">True</property>
-                                    <property name="position">1</property>
+                                    <property name="position">2</property>
                                   </packing>
                                 </child>
                               </object>

--- a/res/asbru.glade
+++ b/res/asbru.glade
@@ -1468,15 +1468,100 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                                         <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_left">20</property>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbCfgRemoveCtrlChars">
+                                                <property name="label" translatable="yes">Remove CONTROL characters. </property>
+                                                <property name="use_action_appearance">False</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="xalign">0</property>
+                                                <property name="draw_indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbCfgLogTimestamp">
+                                                <property name="label" translatable="yes">Add timestamp</property>
+                                                <property name="use_action_appearance">False</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="margin_left">20</property>
+                                                <property name="xalign">0</property>
+                                                <property name="draw_indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label99">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="has_tooltip">True</property>
+                                                <property name="tooltip_text" translatable="yes">0 to keep all session logs</property>
+                                                <property name="label" translatable="yes"> Files to save (0=infinite): </property>
+                                                <property name="xalign">1</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spEditSaveSessionLogs">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="has_tooltip">True</property>
+                                                <property name="tooltip_text" translatable="yes">0 to keep all session logs</property>
+                                                <property name="invisible_char">•</property>
+                                                <property name="text" translatable="yes">0</property>
+                                                <property name="primary_icon_activatable">False</property>
+                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="adjustment">adjFileSave</property>
+                                                <property name="numeric">True</property>
+                                                <property name="update_policy">if-valid</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack_type">end</property>
+                                                <property name="position">3</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkBox" id="hboxEditSaveSessionLogs">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="margin_left">20</property>
                                             <property name="border_width">2</property>
                                             <child>
                                               <object class="GtkLabel" id="label97">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">Save in: </property>
+                                                <property name="margin_right">9</property>
+                                                <property name="label" translatable="yes">Save in</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1489,6 +1574,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="focus_on_click">False</property>
+                                                <property name="margin_right">5</property>
                                                 <property name="action">select-folder</property>
                                                 <property name="title" translatable="yes">Choose a folder for saving log files</property>
                                               </object>
@@ -1541,62 +1627,11 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                                                 <property name="position">2</property>
                                               </packing>
                                             </child>
-                                            <child>
-                                              <object class="GtkCheckButton" id="cbCfgRemoveCtrlChars">
-                                                <property name="label" translatable="yes">Remove CONTROL characters. </property>
-                                                <property name="use_action_appearance">False</property>
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="halign">start</property>
-                                                <property name="xalign">0.5</property>
-                                                <property name="draw_indicator">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">3</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label99">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="has_tooltip">True</property>
-                                                <property name="tooltip_text" translatable="yes">0 to keep all session logs</property>
-                                                <property name="label" translatable="yes"> Files to save (0=infinite): </property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">4</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spEditSaveSessionLogs">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="has_tooltip">True</property>
-                                                <property name="tooltip_text" translatable="yes">0 to keep all session logs</property>
-                                                <property name="invisible_char">•</property>
-                                                <property name="text" translatable="yes">0</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
-                                                <property name="adjustment">adjFileSave</property>
-                                                <property name="numeric">True</property>
-                                                <property name="update_policy">if-valid</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">5</property>
-                                              </packing>
-                                            </child>
                                           </object>
                                           <packing>
                                             <property name="expand">True</property>
                                             <property name="fill">True</property>
-                                            <property name="position">0</property>
+                                            <property name="position">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1608,6 +1643,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                                               <object class="GtkLabel" id="lblEditLogFileName1">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="margin_left">20</property>
                                                 <property name="label" translatable="yes">Logfile name pattern: </property>
                                               </object>
                                               <packing>
@@ -1652,7 +1688,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                                           <packing>
                                             <property name="expand">True</property>
                                             <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -1682,6 +1718,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <object class="GtkBox" id="hbox62">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="margin_top">6</property>
                                 <property name="margin_bottom">6</property>
                                 <child>
                                   <object class="GtkLabel" id="lblUUID">


### PR DESCRIPTION
Fix #603 

Added option to print timestamp on logs.

Terminal settings

![imagen](https://user-images.githubusercontent.com/1572396/81889935-59917b80-956a-11ea-87d3-73a8b692f58e.png)

Example without timestamps

![imagen](https://user-images.githubusercontent.com/1572396/81890196-ff44ea80-956a-11ea-89a1-ad5232c172f7.png)

Example with timestamps

![imagen](https://user-images.githubusercontent.com/1572396/81889970-6ada8800-956a-11ea-917d-411991527f0b.png)

__Limitations.__

The information arrives in chunks with escape sequences, sometimes the information is cut in odd places and only partial information arrives, so eventually some timestamps will not end on a new line, but in between the text. Or some escape sequences can not be cleaned correctly because the timestamp introduces patterns that were not in the original stream.

