### PR TITLE
reset environment keepassword if not set and available

### DIFF
--- a/lib/PACKeePass.pm
+++ b/lib/PACKeePass.pm
@@ -74,6 +74,15 @@ sub new {
     $self->{container} = undef;
     $self->{'last_timestamp'} = '';
 
+    if (!$KPXC_MP) {
+        if ($ENV{'KPXC_MP'}) {
+            $KPXC_MP = $ENV{'KPXC_MP'};
+        } elsif ($$self{cfg}{password}) {
+            $KPXC_MP = $$self{cfg}{password};
+            $ENV{'KPXC_MP'} = $$self{cfg}{password};
+        }
+    }
+
     _setCapabilities($self);
     if ($buildgui) {
         _buildKeePassGUI($self);

--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -308,8 +308,12 @@ sub start {
 
     # If this terminal requires a KeePass database file and that we don't have a connection to a KeePass file yet; ask for the database password now
     if (!$ENV{'KPXC_MP'} && $PACMain::FUNCS{_KEEPASS}->hasKeePassField($$self{_CFG},$$self{_UUID})) {
-        my $kpxc = PACKeePass->new(0, $$self{_CFG}{defaults}{keepass});
-        $kpxc->getMasterPassword($$self{_PARENTWINDOW});
+        if ($$self{_CFG}{defaults}{keepass}{password}) {
+            $ENV{'KPXC_MP'} = $$self{_CFG}{defaults}{keepass}{password};
+        } else {
+            my $kpxc = PACKeePass->new(0, $$self{_CFG}{defaults}{keepass});
+            $kpxc->getMasterPassword($$self{_PARENTWINDOW});
+        }
     }
 
     my $name = $$self{_CFG}{'environments'}{$$self{_UUID}}{'name'};


### PR DESCRIPTION
Modifications for #694 

I can not tell if this affects #694, but something changed in the way environment variables are passed or moved in mint20, or this is an undetected bug.

If the keepass password is set in asbru, it would be asked any way.

