### PR TITLE
Fix694 b

### DIFF
--- a/lib/PACConfig.pm
+++ b/lib/PACConfig.pm
@@ -1040,6 +1040,25 @@ sub _saveConfiguration {
     $$self{_CFG}{'defaults'}{'jump user'} = _($self, 'entryCfgJumpUser')->get_chars(0, -1);
     $$self{_CFG}{'defaults'}{'jump pass'} = _($self, 'entryCfgJumpPass')->get_chars(0, -1);
 
+    # Remove un used settings in network settings to avoid unexpected conflicts
+    if ($$self{_CFG}{'defaults'}{'proxy'} eq 'No') {
+        $$self{_CFG}{'defaults'}{'proxy ip'} = '';
+        $$self{_CFG}{'defaults'}{'proxy user'} = '';
+        $$self{_CFG}{'defaults'}{'proxy pass'} = '';
+        $$self{_CFG}{'defaults'}{'jump ip'} = '';
+        $$self{_CFG}{'defaults'}{'jump user'} = '';
+        $$self{_CFG}{'defaults'}{'jump pass'} = '';
+    } elsif ($$self{_CFG}{'defaults'}{'proxy'} eq 'Proxy') {
+        $$self{_CFG}{'defaults'}{'jump ip'} = '';
+        $$self{_CFG}{'defaults'}{'jump user'} = '';
+        $$self{_CFG}{'defaults'}{'jump pass'} = '';
+    } elsif ($$self{_CFG}{'defaults'}{'proxy'} eq 'Jump') {
+        $$self{_CFG}{'defaults'}{'proxy ip'} = '';
+        $$self{_CFG}{'defaults'}{'proxy user'} = '';
+        $$self{_CFG}{'defaults'}{'proxy pass'} = '';
+    }
+
+
     $$self{_CFG}{'defaults'}{'shell binary'} = _($self, 'entryCfgShellBinary')->get_chars(0, -1);
     $$self{_CFG}{'defaults'}{'shell options'} = _($self, 'entryCfgShellOptions')->get_chars(0, -1);
     $$self{_CFG}{'defaults'}{'shell directory'} = _($self, 'entryCfgShellDirectory')->get_chars(0, -1);

--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -657,6 +657,7 @@ sub _updateGUIPreferences {
     _($self, 'entryCfgProxyConnIP')->set_text($$self{_CFG}{'environments'}{$uuid}{'proxy ip'} // '');
     _($self, 'entryCfgProxyConnPort')->set_value($$self{_CFG}{'environments'}{$uuid}{'proxy port'} // 8080);
     _($self, 'entryCfgProxyConnUser')->set_text($$self{_CFG}{'environments'}{$uuid}{'proxy user'} // '');
+    _($self, 'entryCfgProxyConnPassword')->set_text($$self{_CFG}{'environments'}{$uuid}{'proxy pass'} // '');
     # Jump Server
     _($self, 'entryCfgJumpConnIP')->set_text($$self{_CFG}{'environments'}{$uuid}{'jump ip'} // '');
     _($self, 'entryCfgJumpConnPort')->set_value($$self{_CFG}{'environments'}{$uuid}{'jump port'} // 22);
@@ -888,6 +889,39 @@ sub _saveConfiguration {
     $$self{_CFG}{'environments'}{$uuid}{'remove control chars'} = _($self, 'cbCfgRemoveCtrlChars')->get_active;
     $$self{_CFG}{'environments'}{$uuid}{'log timestamp'} = _($self, 'cbCfgLogTimestamp')->get_active;
 
+    # Remove lefovers from user in : network connections and authentication
+    if ($$self{_CFG}{'environments'}{$uuid}{'auth type'} eq 'userpass') {
+        $$self{_CFG}{'environments'}{$uuid}{'passphrase user'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'passphrase'} = '';
+    } elsif ($$self{_CFG}{'environments'}{$uuid}{'auth type'} eq 'publickey') {
+        $$self{_CFG}{'environments'}{$uuid}{'user'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'pass'} = '';
+    } else {
+        $$self{_CFG}{'environments'}{$uuid}{'passphrase user'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'passphrase'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'user'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'pass'} = '';
+    }
+
+    if ($$self{_CFG}{'environments'}{$uuid}{'use proxy'} == 1) {
+        # Use proxy
+        $$self{_CFG}{'environments'}{$uuid}{'jump ip'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'jump user'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'jump pass'} = '';
+    } elsif ($$self{_CFG}{'environments'}{$uuid}{'use proxy'} == 3) {
+        # Jump Server
+        $$self{_CFG}{'environments'}{$uuid}{'proxy ip'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'proxy user'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'proxy pass'} = '';
+    } else {
+        # Global or direct connection
+        $$self{_CFG}{'environments'}{$uuid}{'proxy ip'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'proxy user'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'proxy pass'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'jump ip'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'jump user'} = '';
+        $$self{_CFG}{'environments'}{$uuid}{'jump pass'} = '';
+    }
     ##################
     # Other options...
     ##################

--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -351,8 +351,12 @@ sub _setupCallbacks {
     _($self, 'btnEditGetCMD')->signal_connect('clicked' => sub {
         # DevNote: please make sure to keep double quotes in "$RealBin/lib/asbru_conn" since it might be replaced by packagers (see RPM spec)
         if (!$ENV{'KPXC_MP'} && $PACMain::FUNCS{_KEEPASS}->hasKeePassField($$self{_CFG},$$self{_UUID})) {
-            my $kpxc = PACKeePass->new(0, $$self{_CFG}{defaults}{keepass});
-            $kpxc->getMasterPassword($$self{_WINDOWEDIT});
+            if ($$self{_CFG}{defaults}{keepass}{password}) {
+                $ENV{'KPXC_MP'} = $$self{_CFG}{defaults}{keepass}{password};
+            } else {
+                my $kpxc = PACKeePass->new(0, $$self{_CFG}{defaults}{keepass});
+                $kpxc->getMasterPassword($$self{_WINDOWEDIT});
+            }
         }
         my $cmd = `"$RealBin/lib/asbru_conn" $CFG_DIR/asbru.nfreeze $$self{_UUID} 0 1`;
         _wMessage($$self{_WINDOWEDIT}, $cmd, 1, 1, 'w-info');
@@ -371,6 +375,9 @@ sub _setupCallbacks {
 
     # Capture 'check keepassx' button clicked
     _($self, 'btnCheckKPX')->signal_connect('clicked' => sub {
+        if (!$ENV{'KPXC_MP'} && $$self{_CFG}{defaults}{keepass}{password}) {
+            $ENV{'KPXC_MP'} = $$self{_CFG}{defaults}{keepass}{password};
+        }
         my $selection = $PACMain::FUNCS{_KEEPASS}->listEntries($$self{_WINDOWEDIT});
         if ($selection) {
             # Commented for the time being, until keepassxc-cli team implements get the UUID

--- a/lib/PACKeePass.pm
+++ b/lib/PACKeePass.pm
@@ -475,7 +475,7 @@ sub hasKeePassField {
         return 0;
     }
 
-    foreach my $fieldName ('user', 'pass', 'passphrase', 'passphrase user', 'ip', 'proxy pass' , 'proxy user') {
+    foreach my $fieldName ('user','pass','passphrase','passphrase user','ip','proxy pass','proxy user','jump ip','jump user','jump pass','proxy ip','proxy user','proxy pass') {
         if ($auth eq 'publickey' && ($fieldName eq 'user' || $fieldName eq 'pass')) {
             # Skip user and pass if public key authorization
             next;
@@ -483,14 +483,31 @@ sub hasKeePassField {
             # Skip passphrase if NOT public key authorization
             next;
         }
-        if ($self->isKeePassMask($$cfg{'environments'}{$uuid}{$fieldName})) {
+        if ($$cfg{'environments'}{$uuid}{$fieldName} && $self->isKeePassMask($$cfg{'environments'}{$uuid}{$fieldName})) {
+            return 1;
+        }
+        if (defined $$cfg{'defaults'}{$fieldName}) {
+            if ($$cfg{'defaults'}{$fieldName} && $self->isKeePassMask($$cfg{'defaults'}{$fieldName})) {
+                return 1;
+            }
+        }
+    }
+
+    # Search for keepass mask in expects
+    foreach my $exp (@{$$cfg{'environments'}{$uuid}{'expect'}}) {
+        if ($self->isKeePassMask($$exp{'send'})) {
             return 1;
         }
     }
 
-    foreach my $exp (@{$$cfg{'environments'}{$uuid}{'expect'}}) {
-        if ($self->isKeePassMask($$exp{'send'})) {
-            return 1;
+    # Search for keepass mask in global variables
+    my $gvars = $$cfg{'defaults'}{'global variables'};
+    foreach my $gvar (keys %$gvars) {
+        my $lgvars = $$cfg{'defaults'}{'global variables'}{$gvar};
+        foreach my $val (keys %$lgvars) {
+            if ($$cfg{'defaults'}{'global variables'}{$gvar}{$val} && $self->isKeePassMask($$cfg{'defaults'}{'global variables'}{$gvar}{$val})) {
+                return 1;
+            }
         }
     }
 

--- a/lib/PACKeePass.pm
+++ b/lib/PACKeePass.pm
@@ -469,12 +469,20 @@ sub hasKeePassField {
     my $uuid = shift;
     my $useKeePass = $$cfg{defaults}{keepass}{use_keepass} && $uuid ne '__PAC_SHELL__';
     my $kpxc;
+    my $auth = $$cfg{'environments'}{$uuid}{'auth type'};
 
     if (!$useKeePass) {
         return 0;
     }
 
     foreach my $fieldName ('user', 'pass', 'passphrase', 'passphrase user', 'ip', 'proxy pass' , 'proxy user') {
+        if ($auth eq 'publickey' && ($fieldName eq 'user' || $fieldName eq 'pass')) {
+            # Skip user and pass if public key authorization
+            next;
+        } elsif ($auth ne 'publickey' && ($fieldName =~ /passphrase/)) {
+            # Skip passphrase if NOT public key authorization
+            next;
+        }
         if ($self->isKeePassMask($$cfg{'environments'}{$uuid}{$fieldName})) {
             return 1;
         }

--- a/lib/PACKeePass.pm
+++ b/lib/PACKeePass.pm
@@ -334,7 +334,12 @@ sub listEntries {
 
     if (!$KPXC_MP) {
         # Get Password user
-        getMasterPassword($self, $parent);
+        if ($$self{cfg}{password}) {
+            $KPXC_MP = $$self{cfg}{password};
+            $ENV{'KPXC_MP'} = $$self{cfg}{password};
+        } else {
+            getMasterPassword($self, $parent);
+        }
     }
     # Create the dialog window,
     $w{window}{data} = Gtk3::Dialog->new_with_buttons(

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -3858,7 +3858,7 @@ sub _doShellEscape {
     my $str = shift;
 
     $str =~ s/([\$\\`"])/\\$1/g;
-    
+
     return $str;
 }
 

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -193,21 +193,24 @@ open_socket();
 if ($$CFG{'defaults'}{'keepass'}{'use_keepass'}) {
     my ($ok);
     $kpxc = PACKeePass->new(0, $$CFG{'defaults'}{'keepass'});
-    ($USER, $ok) = $kpxc->getFieldValueFromString($USER);
-    if (!$ok) {
-        die "$USER";
-    }
-    ($PASS, $ok) = $kpxc->getFieldValueFromString($PASS);
-    if (!$ok) {
-        die "$PASS";
-    }
-    ($PASSPHRASE, $ok) = $kpxc->getFieldValueFromString($PASSPHRASE);
-    if (!$ok) {
-        die "$PASSPHRASE";
-    }
-    ($PASSPHRASE_USER, $ok) = $kpxc->getFieldValueFromString($PASSPHRASE_USER);
-    if (!$ok) {
-        die "$PASSPHRASE_USER";
+    if ($AUTH eq 'publickey') {
+        ($PASSPHRASE, $ok) = $kpxc->getFieldValueFromString($PASSPHRASE);
+        if (!$ok) {
+            die "$PASSPHRASE";
+        }
+        ($PASSPHRASE_USER, $ok) = $kpxc->getFieldValueFromString($PASSPHRASE_USER);
+        if (!$ok) {
+            die "$PASSPHRASE_USER";
+        }
+    } else {
+        ($USER, $ok) = $kpxc->getFieldValueFromString($USER);
+        if (!$ok) {
+            die "$USER";
+        }
+        ($PASS, $ok) = $kpxc->getFieldValueFromString($PASS);
+        if (!$ok) {
+            die "$PASS";
+        }
     }
 } else {
     $USER = subst($USER);
@@ -218,8 +221,10 @@ if ($$CFG{'defaults'}{'keepass'}{'use_keepass'}) {
 $TITLE = subst($TITLE,'GET_TITLE');
 $IP = subst($IP);
 $PORT = subst($PORT);
-$PASSPHRASE = subst($PASSPHRASE);
-$PASSPHRASE_USER = subst($PASSPHRASE_USER);
+if ($AUTH eq 'publickey') {
+    $PASSPHRASE = subst($PASSPHRASE);
+    $PASSPHRASE_USER = subst($PASSPHRASE_USER);
+}
 $$CFG{'environments'}{$UUID}{'proxy ip'}   = subst($$CFG{'environments'}{$UUID}{'proxy ip'});
 $$CFG{'environments'}{$UUID}{'proxy user'} = subst($$CFG{'environments'}{$UUID}{'proxy user'});
 $$CFG{'environments'}{$UUID}{'proxy pass'} = subst($$CFG{'environments'}{$UUID}{'proxy pass'});

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -213,18 +213,19 @@ if ($$CFG{'defaults'}{'keepass'}{'use_keepass'}) {
         }
     }
 } else {
-    $USER = subst($USER);
-    $PASS = subst($PASS);
+    if ($AUTH eq 'publickey') {
+        $PASSPHRASE = subst($PASSPHRASE);
+        $PASSPHRASE_USER = subst($PASSPHRASE_USER);
+    } else {
+        $USER = subst($USER);
+        $PASS = subst($PASS);
+    }
 }
 
 # Translate variables, KeePassXC
 $TITLE = subst($TITLE,'GET_TITLE');
 $IP = subst($IP);
 $PORT = subst($PORT);
-if ($AUTH eq 'publickey') {
-    $PASSPHRASE = subst($PASSPHRASE);
-    $PASSPHRASE_USER = subst($PASSPHRASE_USER);
-}
 $$CFG{'environments'}{$UUID}{'proxy ip'}   = subst($$CFG{'environments'}{$UUID}{'proxy ip'});
 $$CFG{'environments'}{$UUID}{'proxy user'} = subst($$CFG{'environments'}{$UUID}{'proxy user'});
 $$CFG{'environments'}{$UUID}{'proxy pass'} = subst($$CFG{'environments'}{$UUID}{'proxy pass'});


### PR DESCRIPTION
Fix to #694 

__Problem__

* User can leave usless information in disabled elements in : authentication method and network. At global and connection level
* asbru_conn does not revalidates the rules, it simply processes all field in case they are needed
    * So PACKeePass will process anything that asbru_conn sends it without any further validations

__Options__

* Recreate all possible validations in asbru_conn
* Clean up unused fields at save in the corresponding configuration windows

__Solution taken__

Clean up unused fields at save. To maintain asbru_conn simpler.

Additionally, during the process to fix this several issued were fixed around the environment variables and selection of saved keepass password.

The validation of field that could contain keepass masks has been expanded to request or set the master password before calling asbru_conn

Some small validations in the detection process were added to mitigate setting the master password if there are unused fields in the connection settings.

__asbru_conn__

Some logic added to reduce the need to process unused fields in the authentication method.
