### PR TITLE
Add win10 instructions to docs

### DIFF
--- a/doc/General/Installation.md
+++ b/doc/General/Installation.md
@@ -12,6 +12,9 @@ Our master and the snapshots are being kept as stable as possible. New features 
 
 Beware that [Loki](https://en.wikipedia.org/wiki/Loki) can sometimes behave in an unexpected manner to you.  This is somehow the same concept as the "[Debian sid](https://www.debian.org/releases/sid/)" release.
 
+## Windows 10
+It is possible to run Asbru-CM on Windows 10 by enabling WSL and installing [Xming](http://www.straightrunning.com/XmingNotes/). The application [Asbru-CM Runner](https://github.com/SegiH/Asbru-CM-Runner) has detailed instructions on how to do this and allows you to run Asbru-CM on Windows 10 without a console window open in the background.
+
 ## Ubuntu
 **Master release**
 
@@ -136,9 +139,6 @@ To test the latest development package, use the following instructions:
 curl -s https://packagecloud.io/install/repositories/asbru-cm/loki/script.rpm.sh | sudo bash
 sudo dnf install asbru-cm
 ```
-
-## Windows 10
-It is possible to run Asbru-CM on Windows 10 by enabling WSL and installing [Xming](http://www.straightrunning.com/XmingNotes/). The application [Asbru-CM Runner](https://github.com/SegiH/Asbru-CM-Runner) has detailed instructions on how to do this and allows you to run Asbru-CM on Windows 10 without a console window open in the background.
 
 ## Installation of legacy 5.x
 

--- a/doc/General/Installation.md
+++ b/doc/General/Installation.md
@@ -137,6 +137,9 @@ curl -s https://packagecloud.io/install/repositories/asbru-cm/loki/script.rpm.sh
 sudo dnf install asbru-cm
 ```
 
+## Windows 10
+It is possible to run Asbru-CM on Windows 10 by enabling WSL and installing [Xming](http://www.straightrunning.com/XmingNotes/). The application [Asbru-CM Runner](https://github.com/SegiH/Asbru-CM-Runner) has detailed instructions on how to do this and allows you to run Asbru-CM on Windows 10 without a console window open in the background.
+
 ## Installation of legacy 5.x
 
 If you need to install the legacy v5 version of Ásbrú Connection Manager (using Gtk2 library), the legacy packages are still available.


### PR DESCRIPTION
I have added Windows 10 instructions at the top of docs/General/Installation.md

I felt that the Windows 10 section should be at the top of the document because Linux users will be more likely to know that they need to scroll down to find their distro instructions but Windows 10 instructions should be more prominent at the top.

I would also suggest adding this to the Asbru-CM wiki 