### PR TITLE
do not close socket on disconnect only at the time of a full stop

### DIFF
--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -1282,9 +1282,9 @@ sub _setupCallbacks {
             $self->_showEmbedMessages();
         }
 
-        if (defined $$self{_SOCKET_CLIENT}) {
-            $$self{_SOCKET_CLIENT}->close();
-        }
+        #if (defined $$self{_SOCKET_CLIENT}) {
+        #    $$self{_SOCKET_CLIENT}->close();
+        #}
         if (defined $$self{_SOCKET_CLIENT_EXEC}) {
             $$self{_SOCKET_CLIENT_EXEC}->close();
         }


### PR DESCRIPTION
Regarding #502 

I could stop the sysread errors and the high CPU, by commenting the lines that close the socket when a disconnection is issued.

The high cpu and sysread errors on closed file handle, are due to the sockets being closed when other parts still try to read from it.

I have not seen other side effects on the rest of the application by not closing the socket during a disconnect. I could not see oprhaned sockets or some other error introduced by this.

In ubuntu 18.3
As much as I try to follow the code I could not come up with a clear understanding of when the socket creates a high cpu. There are cases where it never happens others where it does randomly.

So you could give it a test and if you think this does not creates other unseen problems by me, it should fix #502 .
