### PR TITLE
Add random sock5 port to connctions and add custom command shortcur

### DIFF
--- a/doc/Manual/Connections/SSH.md
+++ b/doc/Manual/Connections/SSH.md
@@ -40,6 +40,7 @@
 
 ![](images/ssh2.png)
 
++ __Open sock5 tunnel__ : Append '-D <<random port>>' to this ssh connection and use the port to open an application using <<PORT>> as a parameter.
 + __Programmatically send a string__ : Send a specified regex expression every selected seconds to the terminal.
 + __Prepend command__ : Add this command before the ssh command connection string.
 + __Start next script when connection is launched__ : * Pending

--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -332,6 +332,12 @@ sub _setupCallbacks {
         }
     });
 
+    # Capture 'sock5 tunnel' checkbox toggled state
+    _($self, 'sock5TunnelActive')->signal_connect('toggled' => sub {
+        _($self, 'sock5TunnelLabel')->set_sensitive(_($self, 'sock5TunnelActive')->get_active());
+        _($self, 'sock5TunnelCommand')->set_sensitive(_($self, 'sock5TunnelActive')->get_active());
+    });
+
     # Capture 'programatically send string' checkbox toggled state
     _($self, 'cbEditSendString')->signal_connect('toggled' => sub {
         _($self, 'hboxEditSendString')->set_sensitive(_($self, 'cbEditSendString')->get_active());
@@ -691,6 +697,9 @@ sub _updateGUIPreferences {
     _($self, 'comboMethod')->set_active($$self{_METHODS}{$$self{_CFG}{'environments'}{$uuid}{'method'}}{'position'} // 4);
     _($self, 'imageMethod')->set_from_stock('asbru-' . $$self{_CFG}{'environments'}{$uuid}{'method'}, 'button');
     _($self, 'entryTabWindowTitle')->set_text($$self{_CFG}{'environments'}{$uuid}{'title'} || "$$self{_CFG}{'environments'}{$uuid}{'name'} ");
+    _($self, 'sock5TunnelActive')->set_active($$self{_CFG}{'environments'}{$uuid}{'sock5 tunnel active'});
+    _($self, 'sock5TunnelLabel')->set_text($$self{_CFG}{'environments'}{$uuid}{'sock5 tunnel label'} // '');
+    _($self, 'sock5TunnelCommand')->set_text($$self{_CFG}{'environments'}{$uuid}{'sock5 tunnel command'} // '');
     _($self, 'cbEditSendString')->set_active($$self{_CFG}{'environments'}{$uuid}{'send string active'});
     _($self, 'hboxEditSendString')->set_sensitive($$self{_CFG}{'environments'}{$uuid}{'send string active'});
     _($self, 'cbEditSendStringIntro')->set_active($$self{_CFG}{'environments'}{$uuid}{'send string intro'});
@@ -868,6 +877,9 @@ sub _saveConfiguration {
     $$self{_CFG}{'environments'}{$uuid}{'method'} = _($self, 'comboMethod')->get_active_text();
     $$self{_CFG}{'environments'}{$uuid}{'title'} = _($self, 'entryTabWindowTitle')->get_chars(0, -1) || "$$self{_CFG}{'environments'}{$uuid}{'name'} ";
     $$self{_CFG}{'environments'}{$uuid}{'auth fallback'} = ! _($self, 'cbCfgAuthFallback')->get_active();
+    $$self{_CFG}{'environments'}{$uuid}{'sock5 tunnel active'} = _($self, 'sock5TunnelActive')->get_active();
+    $$self{_CFG}{'environments'}{$uuid}{'sock5 tunnel label'} = _($self, 'sock5TunnelLabel')->get_chars(0,-1);
+    $$self{_CFG}{'environments'}{$uuid}{'sock5 tunnel command'} = _($self, 'sock5TunnelCommand')->get_chars(0,-1);
     $$self{_CFG}{'environments'}{$uuid}{'send string active'} = _($self, 'cbEditSendString')->get_active();
     $$self{_CFG}{'environments'}{$uuid}{'send string txt'} = _($self, 'entryEditSendString')->get_chars(0,-1);
     $$self{_CFG}{'environments'}{$uuid}{'send string intro'} = _($self, 'cbEditSendStringIntro')->get_active();

--- a/lib/PACKeyBindings.pm
+++ b/lib/PACKeyBindings.pm
@@ -437,6 +437,7 @@ sub _getDefaultConfig {
     $$cfg{'terminal'}{'Ctrl+0'}        = ['Terminal','zoomreset','Zoom reset text'];
     $$cfg{'terminal'}{'Ctrl+ampersand'}= ['Terminal','cisco','Send Cisco interrupt keypress'];
     $$cfg{'terminal'}{'AltCtrl+s'}     = ['Terminal','sftp','Open SFTP session'];
+    $$cfg{'terminal'}{'AltCtrl+g'}     = ['Terminal','sock5generic','Open sock5 generic command'];
 
     return $cfg;
 }

--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -121,6 +121,7 @@ my $CIPHER = Crypt::CBC->new(-key => 'PAC Manager (David Torrejon Vaquerizas, da
 
 our %RUNNING;
 our %FUNCS;
+our %SOCK5PORTS;
 my @SELECTED_UUIDS;
 
 # END: Define GLOBAL CLASS variables

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -2201,6 +2201,9 @@ sub _cfgSanityCheck {
     $$cfg{'environments'}{'__PAC_SHELL__'}{'use prepend command'} = 0;
     $$cfg{'environments'}{'__PAC_SHELL__'}{'prepend command'} = '';
     $$cfg{'environments'}{'__PAC_SHELL__'}{'quote command'} = 0;
+    $$cfg{'environments'}{'__PAC_SHELL__'}{'sock5 tunnel active'} = 0;
+    $$cfg{'environments'}{'__PAC_SHELL__'}{'sock5 tunnel label'} = '';
+    $$cfg{'environments'}{'__PAC_SHELL__'}{'sock5 tunnel command'} = '';
     $$cfg{'environments'}{'__PAC_SHELL__'}{'send string active'} = 0;
     $$cfg{'environments'}{'__PAC_SHELL__'}{'send string txt'} = '';
     $$cfg{'environments'}{'__PAC_SHELL__'}{'send string intro'} = 1;
@@ -2363,6 +2366,9 @@ sub _cfgSanityCheck {
         $$cfg{'environments'}{$uuid}{'use prepend command'} //= 0;
         $$cfg{'environments'}{$uuid}{'prepend command'} //= '';
         $$cfg{'environments'}{$uuid}{'quote command'} //= 0;
+        $$cfg{'environments'}{$uuid}{'sock5 tunnel active'} //= 0;
+        $$cfg{'environments'}{$uuid}{'sock5 tunnel label'} //= '';
+        $$cfg{'environments'}{$uuid}{'sock5 tunnel command'} //= '';
         $$cfg{'environments'}{$uuid}{'send string active'} //= 0;
         $$cfg{'environments'}{$uuid}{'send string txt'} //= '';
         $$cfg{'environments'}{$uuid}{'send string intro'} //= 1;

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -888,15 +888,16 @@ sub _openSocksTunnel {
 # Find out a free local TCP port
 sub _getLocalPort {
     my $LPORT = shift;
-    my $break = 100;
 
-    while ($break && (my $msg = `netstat -lnt | grep $LPORT 2>&1`)) {
-        if ($msg !~ /:$LPORT/) {
-            # netstat not installed?
-            last;
+    my $PING = Net::Ping->new('tcp');
+    $PING->service_check(0);
+
+    for (my $break = 0; $break < 100; ++$break) {
+        $PING->port_number($LPORT);
+        if (!$PING->ping('localhost')) {
+            return $LPORT;
         }
         $LPORT++;
-        $break--;
     }
     return $LPORT;
 }
@@ -1063,6 +1064,11 @@ if (defined $METHOD) {
     ##############################################
     if (($METHOD =~ /^.*ssh.*$/) || ($METHOD eq 'SSH')) {
         _setProxy('ssh');
+
+        if (defined $$CFG{'tmp'}{'randSock5Port'}) {
+          $CONNECT_OPTS .= ' -D localhost:' . $$CFG{'tmp'}{'randSock5Port'};
+        }
+
         if ($METHOD ne 'autossh') {
             $METHOD = 'ssh';
         }

--- a/res/asbru.glade
+++ b/res/asbru.glade
@@ -1226,6 +1226,112 @@ If not specified or invalid, the default SSH private key of your system will be 
                             <property name="margin_bottom">5</property>
                             <property name="orientation">vertical</property>
                             <child>
+                              <object class="GtkBox" id="hbox570">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="has_tooltip">True</property>
+                                <property name="tooltip_text" translatable="yes">Allows you to open a sock5 tunnel on a random port and use it in the command field to launch other porgrams</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="sock5TunnelActive">
+                                    <property name="label" translatable="yes">Sock5 tunnel</property>
+                                    <property name="use_action_appearance">False</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="label571">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Label:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox571">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkEntry" id="sock5TunnelLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="invisible_char">•</property>
+                                        <property name="activates_default">True</property>
+                                        <property name="primary_icon_activatable">False</property>
+                                        <property name="secondary_icon_activatable">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="label572">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Command:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox572">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkEntry" id="sock5TunnelCommand">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="invisible_char">•</property>
+                                        <property name="activates_default">True</property>
+                                        <property name="primary_icon_activatable">False</property>
+                                        <property name="secondary_icon_activatable">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">4</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkBox" id="hbox57">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -1328,7 +1434,7 @@ If not specified or invalid, the default SSH private key of your system will be 
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
@@ -1408,7 +1514,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
@@ -1447,7 +1553,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
@@ -1711,7 +1817,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
@@ -1754,7 +1860,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -1768,7 +1874,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                           </object>

--- a/utils/asbru_from_superputty.py
+++ b/utils/asbru_from_superputty.py
@@ -160,6 +160,9 @@ elementTemplate = """{uuid}:
   screenshots: ~
   search pass on KPX: 0
   send slow: 0
+  sock5 tunnel active: ''
+  sock5 tunnel label: ''
+  sock5 tunnel command: ''
   send string active: ''
   send string every: 60
   send string intro: 1


### PR DESCRIPTION
I have 2 changes packed in here:

1st small change: remove old netstat and use perl library. In OpenSUSE I don't have netstat anymore, but ss. To avoid having to detect what binary is available I preferred to implement a native perl library.

2nd: add a new option to add a random sock5 port to all connections and allow a custom command to use it:
I often have the need to open a browser tunnelled to a remote connection, with hundreds of connections configured is unfeasible to remember what `-D` ports I've already used, hence the need to add a dynamic random port.
The command I use for testing is `TMP_HOME="$(mktemp -d)"; HOME="${TMP_HOME}" /usr/bin/chromium --incognito --proxy-server="socks5://localhost:<<PORT>>" --proxy-bypass-list="<-loopback>"; rm -Rf "${TMP_HOME}"`


This opens unlimited temporary browsers with no plugins or other customizations, in incognito mode, tunnelled to the remote connection.
Note that if you don't use the temporary home, or have chromium already opened, the proxy option doesn't take effect.
I, for instance, use firefox as my main browser and chromium for this temporary needs.


![image](https://user-images.githubusercontent.com/54575/107216238-64e3db80-6a04-11eb-81ad-4ec8e4c2644d.png)

![image](https://user-images.githubusercontent.com/54575/107216538-d15eda80-6a04-11eb-97f1-570e210f24f6.png)


Please let me know if you have any suggestion, I've been using it for months, but I'm sure it could be further improved.
Thanks