### PR TITLE
Add random socks5 port to connctions and add related variable to use in local commands

### DIFF
--- a/doc/Manual/Connections/SSH.md
+++ b/doc/Manual/Connections/SSH.md
@@ -40,6 +40,7 @@
 
 ![](images/ssh2.png)
 
++ __Open socks5 tunnel__ : Append '-D <<random port>>' to this ssh connection and use the port to open an application using <SOCKS5_PORT> as a parameter.
 + __Programmatically send a string__ : Send a specified regex expression every selected seconds to the terminal.
 + __Prepend command__ : Add this command before the ssh command connection string.
 + __Start next script when connection is launched__ : * Pending

--- a/doc/Manual/Substitutions.md
+++ b/doc/Manual/Substitutions.md
@@ -20,6 +20,7 @@ The general format of the mask is `<[(Name|Type):]VALUE>`.
 |USER              |Connection USER                    |
 |PASS              |Connection Password                |
 |UUID              |Connection UUID                    |
+|SOCKS5_PORT        |Socks5 tunnel port                  |
 |TIMESTAMP         |Elapsed time in seconds since epoch|
 |DATE_Y            |Year                               |
 |DATE_M            |Month                              |

--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -725,6 +725,7 @@ sub _updateGUIPreferences {
     _($self, 'comboMethod')->set_active($$self{_METHODS}{$$self{_CFG}{'environments'}{$uuid}{'method'}}{'position'} // 4);
     _($self, 'imageMethod')->set_from_stock('asbru-' . $$self{_CFG}{'environments'}{$uuid}{'method'}, 'button');
     _($self, 'entryTabWindowTitle')->set_text($$self{_CFG}{'environments'}{$uuid}{'title'} || "$$self{_CFG}{'environments'}{$uuid}{'name'} ");
+    _($self, 'socks5TunnelActive')->set_active($$self{_CFG}{'environments'}{$uuid}{'socks5 tunnel active'});
     _($self, 'cbEditSendString')->set_active($$self{_CFG}{'environments'}{$uuid}{'send string active'});
     _($self, 'hboxEditSendString')->set_sensitive($$self{_CFG}{'environments'}{$uuid}{'send string active'});
     _($self, 'cbEditSendStringIntro')->set_active($$self{_CFG}{'environments'}{$uuid}{'send string intro'});
@@ -904,6 +905,7 @@ sub _saveConfiguration {
     $$self{_CFG}{'environments'}{$uuid}{'method'} = _($self, 'comboMethod')->get_active_text();
     $$self{_CFG}{'environments'}{$uuid}{'title'} = _($self, 'entryTabWindowTitle')->get_chars(0, -1) || "$$self{_CFG}{'environments'}{$uuid}{'name'} ";
     $$self{_CFG}{'environments'}{$uuid}{'auth fallback'} = ! _($self, 'cbCfgAuthFallback')->get_active();
+    $$self{_CFG}{'environments'}{$uuid}{'socks5 tunnel active'} = _($self, 'socks5TunnelActive')->get_active();
     $$self{_CFG}{'environments'}{$uuid}{'send string active'} = _($self, 'cbEditSendString')->get_active();
     $$self{_CFG}{'environments'}{$uuid}{'send string txt'} = _($self, 'entryEditSendString')->get_chars(0,-1);
     $$self{_CFG}{'environments'}{$uuid}{'send string intro'} = _($self, 'cbEditSendStringIntro')->get_active();

--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -121,6 +121,7 @@ my $CIPHER = Crypt::CBC->new(-key => 'PAC Manager (David Torrejon Vaquerizas, da
 
 our %RUNNING;
 our %FUNCS;
+our %SOCKS5PORTS;
 my @SELECTED_UUIDS;
 
 # END: Define GLOBAL CLASS variables

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -2211,6 +2211,7 @@ sub _cfgSanityCheck {
     $$cfg{'environments'}{'__PAC_SHELL__'}{'use prepend command'} = 0;
     $$cfg{'environments'}{'__PAC_SHELL__'}{'prepend command'} = '';
     $$cfg{'environments'}{'__PAC_SHELL__'}{'quote command'} = 0;
+    $$cfg{'environments'}{'__PAC_SHELL__'}{'socks5 tunnel active'} = 0;
     $$cfg{'environments'}{'__PAC_SHELL__'}{'send string active'} = 0;
     $$cfg{'environments'}{'__PAC_SHELL__'}{'send string txt'} = '';
     $$cfg{'environments'}{'__PAC_SHELL__'}{'send string intro'} = 1;
@@ -2373,6 +2374,7 @@ sub _cfgSanityCheck {
         $$cfg{'environments'}{$uuid}{'use prepend command'} //= 0;
         $$cfg{'environments'}{$uuid}{'prepend command'} //= '';
         $$cfg{'environments'}{$uuid}{'quote command'} //= 0;
+        $$cfg{'environments'}{$uuid}{'socks5 tunnel active'} //= 0;
         $$cfg{'environments'}{$uuid}{'send string active'} //= 0;
         $$cfg{'environments'}{$uuid}{'send string txt'} //= '';
         $$cfg{'environments'}{$uuid}{'send string intro'} //= 1;
@@ -2859,13 +2861,14 @@ sub _subst {
     my $string = shift;
     my $CFG = shift;
     my $uuid = shift;
+    my $uuid_tmp = shift;
     my $asbru_conn = shift;
     my $kpxc = shift;
     my $ret = $string;
     my %V = ();
     my %out;
     my $pos = -1;
-    my @LOCAL_VARS = ('UUID','TIMESTAMP','DATE_Y','DATE_M','DATE_D','TIME_H','TIME_M','TIME_S','NAME','TITLE','IP','PORT','USER','PASS');
+    my @LOCAL_VARS = ('UUID','SOCKS5_PORT','TIMESTAMP','DATE_Y','DATE_M','DATE_D','TIME_H','TIME_M','TIME_S','NAME','TITLE','IP','PORT','USER','PASS');
     my $parent;
 
     if ($uuid) {
@@ -2886,6 +2889,11 @@ sub _subst {
         $V{'PORT'}  = $$CFG{'environments'}{$uuid}{port};
         $V{'USER'}  = $$CFG{'environments'}{$uuid}{user};
         $V{'PASS'}  = $$CFG{'environments'}{$uuid}{pass};
+        if ($$CFG{'environments'}{$uuid}{'socks5 tunnel active'} and defined $PACMain::SOCKS5PORTS{$uuid_tmp}) {
+          $V{'SOCKS5_PORT'} = $PACMain::SOCKS5PORTS{$uuid_tmp};
+        } else {
+          $V{'SOCKS5_PORT'} = "";
+        }
     }
     $V{'TIMESTAMP'} = time;
     ($V{'DATE_Y'},$V{'DATE_M'},$V{'DATE_D'},$V{'TIME_H'},$V{'TIME_M'},$V{'TIME_S'}) = split('_', strftime("%Y_%m_%d_%H_%M_%S", localtime));

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -383,7 +383,7 @@ sub subst {
     }
 
     # Reuse most of the implementation in PACUtils.pm
-    $string = _subst($string,$CFG,$UUID,1,$kpxc);
+    $string = _subst($string,$CFG,$UUID,$TMP_UUID,1,$kpxc);
 
     # Use local wEnterValue routine
     # Replace '<ASK:#>' with user provided data for 'cmd' execution
@@ -1077,6 +1077,11 @@ if (defined $METHOD) {
     ##############################################
     if (($METHOD =~ /^.*ssh.*$/) || ($METHOD eq 'SSH')) {
         _setProxy('ssh');
+
+        if (defined $$CFG{'tmp'}{'randSocks5Port'}) {
+          $CONNECT_OPTS .= ' -D localhost:' . $$CFG{'tmp'}{'randSocks5Port'};
+        }
+
         if ($METHOD ne 'autossh') {
             $METHOD = 'ssh';
         }

--- a/lib/edit/PACExecEntry.pm
+++ b/lib/edit/PACExecEntry.pm
@@ -465,6 +465,7 @@ sub _buildExec {
         # Populate with Ásbrú Connection Manager internal variables
         my @int_variables_menu;
         push(@int_variables_menu, {label => "UUID",      code => sub {$w{txt}->insert_text("<UUID>",      -1, $w{txt}->get_position());} });
+        push(@int_variables_menu, {label => "SOCKS5_PORT",code => sub {$w{txt}->insert_text("<SOCKS5_PORT>",-1, $w{txt}->get_position());} });
         push(@int_variables_menu, {label => "TIMESTAMP", code => sub {$w{txt}->insert_text("<TIMESTAMP>", -1, $w{txt}->get_position());} });
         push(@int_variables_menu, {label => "DATE_Y",    code => sub {$w{txt}->insert_text("<DATE_Y>",    -1, $w{txt}->get_position());} });
         push(@int_variables_menu, {label => "DATE_M",    code => sub {$w{txt}->insert_text("<DATE_M>",    -1, $w{txt}->get_position());} });

--- a/lib/edit/PACExpectEntry.pm
+++ b/lib/edit/PACExpectEntry.pm
@@ -700,6 +700,7 @@ sub _buildExpect {
         # Populate with Ásbrú Connection Manager internal variables
         my @int_variables_menu;
         push(@int_variables_menu, {label => "UUID",code => sub {$w{send}->insert_text("<UUID>", -1, $w{send}->get_position);} });
+        push(@int_variables_menu, {label => "SOCKS5_PORT",code => sub {$w{send}->insert_text("<SOCKS5_PORT>",-1, $w{send}->get_position());} });
         push(@int_variables_menu, {label => "TIMESTAMP",code => sub {$w{send}->insert_text("<TIMESTAMP>", -1, $w{send}->get_position);} });
         push(@int_variables_menu, {label => "DATE_Y",code => sub {$w{send}->insert_text("<DATE_Y>", -1, $w{send}->get_position);} });
         push(@int_variables_menu, {label => "DATE_M",code => sub {$w{send}->insert_text("<DATE_M>", -1, $w{send}->get_position);} });
@@ -815,6 +816,7 @@ sub _buildExpect {
         # Populate with Ásbrú Connection Manager internal variables
         my @int_variables_menu;
         push(@int_variables_menu, {label => "UUID",code => sub {$w{send}->insert_text("<UUID>", -1, $w{send}->get_position);} });
+        push(@int_variables_menu, {label => "SOCKS5_PORT",code => sub {$w{send}->insert_text("<SOCKS5_PORT>",-1, $w{send}->get_position());} });
         push(@int_variables_menu, {label => "TIMESTAMP",code => sub {$w{send}->insert_text("<TIMESTAMP>", -1, $w{send}->get_position);} });
         push(@int_variables_menu, {label => "DATE_Y",code => sub {$w{send}->insert_text("<DATE_Y>", -1, $w{send}->get_position);} });
         push(@int_variables_menu, {label => "DATE_M",code => sub {$w{send}->insert_text("<DATE_M>", -1, $w{send}->get_position);} });

--- a/lib/edit/PACPrePostEntry.pm
+++ b/lib/edit/PACPrePostEntry.pm
@@ -326,6 +326,7 @@ sub _buildPrePost {
         # Populate with Ásbrú Connection Manager internal variables
         my @int_variables_menu;
         push(@int_variables_menu, {label => "UUID",code => sub {$w{command}->insert_text("<UUID>", -1, $w{command}->get_position);} });
+        push(@int_variables_menu, {label => "SOCKS5_PORT",code => sub {$w{command}->insert_text("<SOCKS5_PORT>",-1, $w{command}->get_position());} });
         push(@int_variables_menu, {label => "TIMESTAMP",code => sub {$w{command}->insert_text("<TIMESTAMP>", -1, $w{command}->get_position);} });
         push(@int_variables_menu, {label => "DATE_Y",code => sub {$w{command}->insert_text("<DATE_Y>", -1, $w{command}->get_position);} });
         push(@int_variables_menu, {label => "DATE_M",code => sub {$w{command}->insert_text("<DATE_M>", -1, $w{command}->get_position);} });

--- a/res/asbru.glade
+++ b/res/asbru.glade
@@ -1268,6 +1268,36 @@ If not specified or invalid, the default SSH private key of your system will be 
                             <property name="margin_bottom">5</property>
                             <property name="orientation">vertical</property>
                             <child>
+                              <object class="GtkBox" id="hbox570">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="has_tooltip">True</property>
+                                <property name="tooltip_text" translatable="yes">Allows you to open a socks5 tunnel on a random port and use it in the command field to launch other porgrams</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="socks5TunnelActive">
+                                    <property name="label" translatable="yes">Random Socks5 tunnel</property>
+                                    <property name="use_action_appearance">False</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkBox" id="hbox57">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -1370,7 +1400,7 @@ If not specified or invalid, the default SSH private key of your system will be 
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
@@ -1450,7 +1480,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
@@ -1489,7 +1519,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
@@ -1702,6 +1732,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                                                 <property name="tooltip_text" translatable="yes">Logfile pattern:
 
 &lt;UUID&gt; -&gt; UUID for this connection
+&lt;SOCKS5_PORT&gt; -&gt; Socks5 tunnel port
 &lt;TIMESTAMP&gt; -&gt; time since epoc
 &lt;DATE_Y&gt; -&gt; Year(4 digits)
 &lt;DATE_M&gt; -&gt; Month(2 digits)
@@ -1715,7 +1746,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
 &lt;USER&gt; -&gt; Username for first jump
 </property>
                                                 <property name="invisible_char">•</property>
-                                                <property name="text" translatable="yes">&lt;UUID&gt;_&lt;NAME&gt;_&lt;DATE_Y&gt;&lt;DATE_M&gt;&lt;DATE_D&gt;_&lt;TIME_H&gt;&lt;TIME_M&gt;&lt;TIME_S&gt;.txt</property>
+                                                <property name="text" translatable="yes">&lt;UUID&gt;_&lt;SOCKS5_PORT&gt;_&lt;NAME&gt;_&lt;DATE_Y&gt;&lt;DATE_M&gt;&lt;DATE_D&gt;_&lt;TIME_H&gt;&lt;TIME_M&gt;&lt;TIME_S&gt;.txt</property>
                                                 <property name="caps_lock_warning">False</property>
                                                 <property name="primary_icon_activatable">False</property>
                                                 <property name="secondary_icon_activatable">False</property>
@@ -1753,7 +1784,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
@@ -1796,7 +1827,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -1810,7 +1841,7 @@ Or(Global Variable): DISPLAY=&lt;GV:DISPLAY&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                           </object>
@@ -5928,6 +5959,7 @@ sudo -p sudo_prompt_string ...</property>
                                         <property name="tooltip_text" translatable="yes">Logfile pattern:
 
 &lt;UUID&gt; -&gt; UUID for this connection
+&lt;SOCKS5_PORT&gt; -&gt; Socks5 tunnel port
 &lt;TIMESTAMP&gt; -&gt; time since epoc
 &lt;DATE_Y&gt; -&gt; Year(4 digits)
 &lt;DATE_M&gt; -&gt; Month(2 digits)
@@ -5941,7 +5973,7 @@ sudo -p sudo_prompt_string ...</property>
 &lt;USER&gt; -&gt; Username for first jump
 </property>
                                         <property name="invisible_char">•</property>
-                                        <property name="text" translatable="yes">&lt;UUID&gt;_&lt;NAME&gt;_&lt;DATE_Y&gt;&lt;DATE_M&gt;&lt;DATE_D&gt;_&lt;TIME_H&gt;&lt;TIME_M&gt;&lt;TIME_S&gt;.txt</property>
+                                        <property name="text" translatable="yes">&lt;UUID&gt;_&lt;SOCKS5_PORT&gt;_&lt;NAME&gt;_&lt;DATE_Y&gt;&lt;DATE_M&gt;&lt;DATE_D&gt;_&lt;TIME_H&gt;&lt;TIME_M&gt;&lt;TIME_S&gt;.txt</property>
                                         <property name="caps_lock_warning">False</property>
                                         <property name="primary_icon_activatable">False</property>
                                         <property name="secondary_icon_activatable">False</property>

--- a/utils/asbru_from_superputty.py
+++ b/utils/asbru_from_superputty.py
@@ -160,6 +160,7 @@ elementTemplate = """{uuid}:
   screenshots: ~
   search pass on KPX: 0
   send slow: 0
+  socks5 tunnel active: ''
   send string active: ''
   send string every: 60
   send string intro: 1


### PR DESCRIPTION
Following the previous epiphany on pull request #762 I've reimplemented this function as a local command.
The functionality I had intended is still the same, and I'm happy with both implementations, but I think this way it integrates better with what's already there.

Just as an example, the command I use with this new variable is: `bash -c 'TMP_HOME="$(mktemp -d)"; HOME="${TMP_HOME}" /usr/bin/chromium --incognito --proxy-server="socks5://localhost:<SOCKS5_PORT>" --proxy-bypass-list="<-loopback>"; rm -Rf "${TMP_HOME}"'`

Thanks