### PR TITLE
Do not mention yaourt

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ To do so, execute the following commands:
   $ sudo dnf install asbru-cm
   ````
 
-- Arch / Manjaro
+- Pacman-based (e.g. Arch Linux, Manjaro)
 
   ````
-  yaourt -S asbru-cm-git
+  git clone https://aur.archlinux.org/asbru-cm-git.git && cd asbru-cm-git
+  makepkg -si
   ````
   
 - MX Linux


### PR DESCRIPTION
yaourt has been abandoned for several years now. It lacks many features and has many security issues.

I changed the mention so now it mentions [the manual install process](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages). I do not believe that any AUR helper should be promoted. It is up to user which one they want to use.

Also changed line so it says that the instructions are for pacman-based distros. This is because pacman contains the makepkg tool.