### PR TITLE
remove all embedded which checks and replace them with system

### DIFF
--- a/lib/PACScripts.pm
+++ b/lib/PACScripts.pm
@@ -41,7 +41,7 @@ use Storable qw (dclone nstore_fd);
 eval {require Gtk3::SourceView2;};
 my $SOURCEVIEW = ! $@;
 
-my $PERL = `which perl 2>&1`;
+my $PERL = (system("which perl &>/dev/null") eq 0);
 
 # GTK
 use Gtk3 '-init';

--- a/lib/PACUtils.pm
+++ b/lib/PACUtils.pm
@@ -368,10 +368,9 @@ sub _getMethods {
         $THEME_DIR = $theme_dir;
     }
 
-    `which rdesktop 1>/dev/null 2>&1`;
-    my $rdesktop = $?;
+    my $rdesktop = (system("which rdesktop &>/dev/null") eq 0);
     $methods{'RDP (rdesktop)'} = {
-        'installed' => sub {return (! $rdesktop) ? 1 : "No 'rdesktop' binary found.\nTo use this option, please, install :'rdesktop'";},
+        'installed' => sub {return $rdesktop ? 1 : "No 'rdesktop' binary found.\nTo use this option, please, install :'rdesktop'";},
         'checkCFG' => sub {
             my $cfg = shift;
 
@@ -440,10 +439,9 @@ sub _getMethods {
         'escape' => ["\cc"]
     };
 
-    `which xfreerdp 1>/dev/null 2>&1`;
-    my $xfreerdp = $?;
+    my $xfreerdp = (system("which xfreerdp &>/dev/null") eq 0);
     $methods{'RDP (xfreerdp)'} = {
-        'installed' => sub {return (! $xfreerdp) ? 1 : "No 'xfreerdp' binary found.\nTo use this option, please, install:\n'freerdp2-x11'";},
+        'installed' => sub {return $xfreerdp ? 1 : "No 'xfreerdp' binary found.\nTo use this option, please, install:\n'freerdp2-x11'";},
         'checkCFG' => sub {
             my $cfg = shift;
 
@@ -512,12 +510,10 @@ sub _getMethods {
         'escape' => ["\cc"]
     };
 
-    `which vncviewer 1>/dev/null 2>&1`;
-    my $xtightvncviewer = $?;
-    `vncviewer --help 2>&1 | /bin/grep TigerVNC`;
-    my $tigervnc = $?;
+    my $xtightvncviewer = (system("which vncviewer &>/dev/null") eq 0);
+    my $tigervnc = (system("vncviewer --help 2>&1 | /bin/grep -q TigerVNC") eq 0);
     $methods{'VNC'} = {
-        'installed' => sub {return ! $xtightvncviewer || ! $tigervnc ? 1 : "No 'vncviewer' binary found.\nTo use this option, please, install any of:\n'xtightvncviewer' or 'tigervnc'\n'tigervnc' is preferred, since it allows embedding its window into Ásbrú Connection Manager.";},
+        'installed' => sub {return $xtightvncviewer || $tigervnc ? 1 : "No 'vncviewer' binary found.\nTo use this option, please, install any of:\n'xtightvncviewer' or 'tigervnc'\n'tigervnc' is preferred, since it allows embedding its window into Ásbrú Connection Manager.";},
         'checkCFG' => sub {
 
             my $cfg = shift;
@@ -582,10 +578,9 @@ sub _getMethods {
         'escape' => ["\cc"]
     };
 
-    `which cu 1>/dev/null 2>&1`;
-    my $cu = $?;
+    my $cu = (system("which cu &>/dev/null") eq 0);
     $methods{'Serial (cu)'} = {
-        'installed' => sub {return ! $cu ? 1 : "No 'cu' binary found.\nTo use this option, please, install 'cu'.";},
+        'installed' => sub {return $cu ? 1 : "No 'cu' binary found.\nTo use this option, please, install 'cu'.";},
         'checkCFG' => sub {
             my $cfg = shift;
 
@@ -633,10 +628,9 @@ sub _getMethods {
         'escape' => ['~.']
     };
 
-    `which remote-tty 1>/dev/null 2>&1`;
-    my $remote_tty = $?;
+    my $remote_tty = (system("which remote-tty &>/dev/null") eq 0);
     $methods{'Serial (remote-tty)'} = {
-        'installed' => sub {return ! $remote_tty ? 1 : "No 'remote-tty' binary found.\nTo use this option, please, install 'remote-tty'.";},
+        'installed' => sub {return $remote_tty ? 1 : "No 'remote-tty' binary found.\nTo use this option, please, install 'remote-tty'.";},
         'checkCFG' => sub {
             my $cfg = shift;
 
@@ -700,10 +694,9 @@ sub _getMethods {
         'icon' => Gtk3::Gdk::Pixbuf->new_from_file_at_scale("$THEME_DIR/asbru_method_remote-tty.jpg", 16, 16, 0)
     };
 
-    `which c3270 1>/dev/null 2>&1`;
-    my $c3270 = $?;
+    my $c3270 = (system("which c3270 &>/dev/null") eq 0);
     $methods{'IBM 3270/5250'} = {
-        'installed' => sub {return ! $c3270 ? 1 : "No 'c3270' binary found.\nTo use this option, please, install 'c3270' or 'x3270-text'.";},
+        'installed' => sub {return $c3270 ? 1 : "No 'c3270' binary found.\nTo use this option, please, install 'c3270' or 'x3270-text'.";},
         'checkCFG' => sub {
             my $cfg = shift;
 
@@ -753,8 +746,7 @@ sub _getMethods {
         'icon' => Gtk3::Gdk::Pixbuf->new_from_file_at_scale("$THEME_DIR/asbru_method_3270.jpg", 16, 16, 0)
     };
 
-    `which autossh 1>/dev/null 2>&1`;
-    my $autossh = ! $?;
+    my $autossh = (system("which autossh &>/dev/null") eq 0);
     $methods{'SSH'} = {
         'installed' => sub {return 1;},
         'checkCFG' => sub {
@@ -817,10 +809,9 @@ sub _getMethods {
         'escape' => ['~.']
     };
 
-    `which mosh 1>/dev/null 2>&1`;
-    my $mosh = $?;
+    my $mosh = (system("which mosh &>/dev/null") eq 0);
     $methods{'MOSH'} = {
-        'installed' => sub {return ! $mosh ? 1 : "No 'mosh' binary found.\nTo use this option, please, install 'mosh'.";},
+        'installed' => sub {return $mosh ? 1 : "No 'mosh' binary found.\nTo use this option, please, install 'mosh'.";},
         'checkCFG' => sub {
             my $cfg = shift;
 
@@ -883,10 +874,9 @@ sub _getMethods {
         'escape' => ["\c^x."]
     };
 
-    `which cadaver 1>/dev/null 2>&1`;
-    my $cadaver = $?;
+    my $cadaver = (system("which cadaver &>/dev/null") eq 0);
     $methods{'WebDAV'} = {
-        'installed' => sub {return ! $cadaver ? 1 : "No 'cadaver' binary found.\nTo use this option, please, install 'cadaver'.";},
+        'installed' => sub {return $cadaver ? 1 : "No 'cadaver' binary found.\nTo use this option, please, install 'cadaver'.";},
         'checkCFG' => sub {
             my $cfg = shift;
 
@@ -949,10 +939,9 @@ sub _getMethods {
         'escape' => ["\cc", "quit\n"]
     };
 
-    `which telnet 1>/dev/null 2>&1`;
-    my $telnet = $?;
+    my $telnet = (system("which telnet &>/dev/null") eq 0);
     $methods{'Telnet'} = {
-        'installed' => sub {return ! $telnet ? 1 : "No 'telnet' binary found.\nTo use this option, please, install 'telnet' or 'telnet-ssl'.";},
+        'installed' => sub {return $telnet ? 1 : "No 'telnet' binary found.\nTo use this option, please, install 'telnet' or 'telnet-ssl'.";},
         'checkCFG' => sub {
             my $cfg = shift;
             my @faults;

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -136,8 +136,7 @@ $CFG = retrieve($CFG_FILE) or die "ERROR: Could not load config file '$CFG_FILE'
 # Check some command line options
 defined $$CFG{'environments'}{$UUID} or die("ERROR: Profile '$UUID' does not exist!!");
 
-`which autossh 1>/dev/null 2>&1`;
-my $autossh_bin = ! $?;
+my $autossh_bin = (system("which autossh &>/dev/null") eq 0);
 
 # Shorten some variables
 my $DEBUG = $$CFG{'defaults'}{'debug'};
@@ -857,8 +856,7 @@ sub _getProxyCmd {
     my ($proxy_type, $proxy_ip, $proxy_port, $proxy_user, $proxy_pass) = @_;
 
     if ($proxy_user ne '') {
-        `which ncat 1>/dev/null 2>&1`;
-        if (! $?) {
+        if (system("which ncat &>/dev/null") eq 0) {
             return "ncat --proxy $proxy_ip:$proxy_port --proxy-type $proxy_type --proxy-auth $proxy_user:$proxy_pass";
         }
         print("$COLOR{'err'}ERROR$COLOR{'norm'}: ncat is required if using proxy user/password.\nncat is part of the nmap project (https://nmap.org/ncat/).\n");


### PR DESCRIPTION
Hi,

I have a problem with the detection of xfreerdp, for some reason https://github.com/asbru-cm/asbru-cm/blob/master/lib/PACUtils.pm#L443-L446 doesn't work for me.
But because I find the way `which` is used very ugly and inconsistent, I've decided to change all of them with `system("") eq 0`.
This way the variables `my $PERL`, `my $xfreerdp`, `my $xtightvncviewer`, etc.. now contain a value already sanitized that can be used as is.