### PR TITLE
Add options in preferences to show port forwarding (full or short) in statusbar (#742)

### DIFF
--- a/lib/PACConfig.pm
+++ b/lib/PACConfig.pm
@@ -250,6 +250,15 @@ sub _setupCallbacks {
             _($self, 'cbCfgButtonBarAutoHide')->set_active(0);
         }
     });
+    _($self, 'cbCfgStatusBar')->signal_connect('toggled' => sub {
+        _($self, 'rbCfgStatusShort')->set_sensitive(_($self, 'cbCfgStatusBar')->get_active());
+        _($self, 'rbCfgStatusFull')->set_sensitive(_($self, 'cbCfgStatusBar')->get_active());
+        if (!_($self, 'cbCfgStatusBar')->get_active()) {
+            # Set safe values other wise options would be unaccesible
+            _($self, 'rbCfgStatusShort')->set_active(0);
+            _($self, 'rbCfgStatusFull')->set_active(0);
+        }
+    });
     _($self, 'cbCfgNewInTab')->signal_connect('toggled' => sub {
         _($self, 'vboxCfgTabsOptions')->set_sensitive(_($self, 'cbCfgNewInTab')->get_active());
     });
@@ -802,6 +811,9 @@ sub _updateGUIPreferences {
     _($self, 'cbCfgButtonBarAutoHide')->set_active($$cfg{'defaults'}{'auto hide button bar'});
     _($self, 'cbCfgButtonBarAutoHide')->set_sensitive(_($self, 'cbCfgTabsInMain')->get_active());
     _($self, 'cbCfgPreventMOShowTree')->set_sensitive(_($self, 'cbCfgTabsInMain')->get_active());
+    _($self, 'cbCfgStatusBar')->set_active($$cfg{'defaults'}{'info in status bar'});
+    _($self, 'rbCfgStatusShort')->set_active(! $$cfg{'defaults'}{'forwarding short names'});
+    _($self, 'rbCfgStatusFull')->set_active($$cfg{'defaults'}{'forwarding full names'});
     _($self, 'entryCfgPrompt')->set_text($$cfg{'defaults'}{'command prompt'});
     _($self, 'entryCfgUserPrompt')->set_text($$cfg{'defaults'}{'username prompt'});
     _($self, 'entryCfgPasswordPrompt')->set_text($$cfg{'defaults'}{'password prompt'});
@@ -1045,6 +1057,9 @@ sub _saveConfiguration {
     $$self{_CFG}{'defaults'}{'tabs in main window'} = _($self, 'cbCfgTabsInMain')->get_active();
     $$self{_CFG}{'defaults'}{'auto hide connections list'} = _($self, 'cbCfgConnectionsAutoHide')->get_active();
     $$self{_CFG}{'defaults'}{'auto hide button bar'} = _($self, 'cbCfgButtonBarAutoHide')->get_active();
+    $$self{_CFG}{'defaults'}{'info in status bar'} = _($self, 'cbCfgStatusBar')->get_active();
+    $$self{_CFG}{'defaults'}{'forwarding short names'} = _($self, 'rbCfgStatusShort')->get_active();
+    $$self{_CFG}{'defaults'}{'forwarding full names'} = _($self, 'rbCfgStatusFull')->get_active();
     $$self{_CFG}{'defaults'}{'hide on connect'} = _($self, 'cbCfgHideOnConnect')->get_active();
     $$self{_CFG}{'defaults'}{'force split tabs to 50%'} = _($self, 'cbCfgForceSplitSize')->get_active();
     $$self{_CFG}{'defaults'}{'start iconified'} = _($self, 'cbCfgStartIconified')->get_active();

--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -2444,9 +2444,15 @@ sub _setTabColour {
 
 sub _updateStatus {
     my $self = shift;
-    my $forwardports = '';
+    my $forward_ports = '';
+    
+    # Show forwarding in status bar
     if ($self->{CONNECTED} && $$self{_CFG}{environments}{$$self{_UUID}}{method} eq 'SSH'){
-        ( $forwardports ) = $$self{_CFG}{environments}{$$self{_UUID}}{options} =~ /((-L|-D|-R)(.+))/;
+        ( $forward_ports ) = $$self{_CFG}{environments}{$$self{_UUID}}{options} =~ /((-L|-D|-R)(.+))/;
+        $forward_ports =~ s/-L/Local Forwarding:/;
+        $forward_ports =~ s/-R/Remote Forwarding:/;
+        $forward_ports =~ s/-D/Dynamic Forwarding:/;
+        $forward_ports =~ s/(-L|-R|-D) //g
     }
 
     if (!defined $$self{_GUI}{status}) {
@@ -2459,9 +2465,9 @@ sub _updateStatus {
 
     # Control CLUSTER status
     if ($$self{_CLUSTER} ne '') {
-        $$self{_GUI}{status}->push(0, "[IN CLUSTER: $$self{_CLUSTER}] - Status: $$self{_LAST_STATUS} $forwardports");
+        $$self{_GUI}{status}->push(0, "[IN CLUSTER: $$self{_CLUSTER}] - Status: $$self{_LAST_STATUS} $forward_ports");
     } else {
-        $$self{_GUI}{status}->push(0, "Status: $$self{_LAST_STATUS} $forwardports");
+        $$self{_GUI}{status}->push(0, "Status: $$self{_LAST_STATUS} $forward_ports");
     }
 
     if (defined $$self{_GUI}{status}) {

--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -2447,12 +2447,16 @@ sub _updateStatus {
     my $forward_ports = '';
     
     # Show forwarding in status bar
-    if ($self->{CONNECTED} && $$self{_CFG}{environments}{$$self{_UUID}}{method} eq 'SSH'){
+    if ($self->{CONNECTED} && 
+    	$$self{_CFG}{environments}{$$self{_UUID}}{method} eq 'SSH' &&
+    	$$self{_CFG}{defaults}{'info in status bar'}){
         ( $forward_ports ) = $$self{_CFG}{environments}{$$self{_UUID}}{options} =~ /((-L|-D|-R)(.+))/;
-        $forward_ports =~ s/-L/Local Forwarding:/;
-        $forward_ports =~ s/-R/Remote Forwarding:/;
-        $forward_ports =~ s/-D/Dynamic Forwarding:/;
-        $forward_ports =~ s/(-L|-R|-D) //g
+        if ($$self{_CFG}{defaults}{'forwarding full names'}){
+            $forward_ports =~ s/-L/Local Forwarding:/;
+            $forward_ports =~ s/-R/Remote Forwarding:/;
+            $forward_ports =~ s/-D/Dynamic Forwarding:/;
+            $forward_ports =~ s/(-L|-R|-D) //g
+        }
     }
 
     if (!defined $$self{_GUI}{status}) {

--- a/lib/PACTerminal.pm
+++ b/lib/PACTerminal.pm
@@ -2444,6 +2444,10 @@ sub _setTabColour {
 
 sub _updateStatus {
     my $self = shift;
+    my $forwardports = '';
+    if ($self->{CONNECTED} && $$self{_CFG}{environments}{$$self{_UUID}}{method} eq 'SSH'){
+        ( $forwardports ) = $$self{_CFG}{environments}{$$self{_UUID}}{options} =~ /((-L|-D|-R)(.+))/;
+    }
 
     if (!defined $$self{_GUI}{status}) {
         return 1;
@@ -2455,9 +2459,9 @@ sub _updateStatus {
 
     # Control CLUSTER status
     if ($$self{_CLUSTER} ne '') {
-        $$self{_GUI}{status}->push(0, "[IN CLUSTER: $$self{_CLUSTER}] - Status: $$self{_LAST_STATUS}");
+        $$self{_GUI}{status}->push(0, "[IN CLUSTER: $$self{_CLUSTER}] - Status: $$self{_LAST_STATUS} $forwardports");
     } else {
-        $$self{_GUI}{status}->push(0, "Status: $$self{_LAST_STATUS}");
+        $$self{_GUI}{status}->push(0, "Status: $$self{_LAST_STATUS} $forwardports");
     }
 
     if (defined $$self{_GUI}{status}) {

--- a/res/asbru.glade
+++ b/res/asbru.glade
@@ -4921,6 +4921,105 @@ Otherwise, only the icon will be shown and save screen space.</property>
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkSeparator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">4</property>
+                        <property name="margin_bottom">4</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">16</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkFrame" id="frameStatusBar">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="border_width">0</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkAlignment" id="alignment10">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="left_padding">40</property>
+                            <child>
+                              <object class="GtkBox" id="hbox69">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                <object class="GtkBox" id="vbox38">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                    <object class="GtkRadioButton" id="rbCfgStatusFull">
+                                        <property name="label" translatable="yes">Use full names (Local Forwarding, Remote Forwarding, Dynamic Forwarding)</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="active">True</property>
+                                        <property name="draw_indicator">True</property>
+                                    </object>
+                                    <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                    </packing>
+                                    </child>
+                                    <child>
+                                    <object class="GtkRadioButton" id="rbCfgStatusShort">
+                                        <property name="label" translatable="yes">Use abreviatures (-L, -R, -D)</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw_indicator">True</property>
+                                        <property name="group">rbCfgStatusFull</property>
+                                    </object>
+                                    <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                    </packing>
+                                    </child>
+                                </object>
+                                <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="label">
+                          <object class="GtkCheckButton" id="cbCfgStatusBar">
+                            <property name="label" translatable="yes">Show port forwarding information in status bar</property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="has_tooltip">True</property>
+                            <property name="tooltip_text" translatable="yes">If checked, show port forwarding information in status bar when connected</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">17</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkLabel" id="lblRestartRequired1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -4933,7 +5032,7 @@ Otherwise, only the icon will be shown and save screen space.</property>
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
-                        <property name="position">16</property>
+                        <property name="position">18</property>
                       </packing>
                     </child>
                   </object>


### PR DESCRIPTION
Add options in preferences to:
- Show port forwarding information in status bar
If yes:
- Use full names (Local Forwarding, Remote Forwarding, Dynamic Forwarding)
- Use abreviatures (-L, -R, -D)