### PR TITLE
Execute in new cluster warning message

### DIFF
--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -3219,7 +3219,7 @@ sub _launchTerminals {
             _wMessage($$self{_GUI}{main}, "ERROR: UUID <b>$uuid</b> does not exist in DDBB\nNot starting connection!", 1);
             next;
         } elsif ($$self{_CFG}{'environments'}{$uuid}{_is_group} || ($uuid eq '__PAC__ROOT__')) {
-            _wMessage($$self{_GUI}{main}, "ERROR: UUID <b>$uuid</b> is a GROUP\nNot starting anything!", 1);
+            # _wMessage($$self{_GUI}{main}, "ERROR: UUID <b>$uuid</b> is a GROUP\nNot starting anything!", 1);
             next;
         }
         my $pset = $$self{_CFG}{'environments'}{$uuid}{'terminal options'}{'open in tab'} ? 'tab' : 'window';


### PR DESCRIPTION
Hi,
So, I've a complex folder structure with nested folders, up to 3 or 4 levels in some cases.
When I right click on a folder and do "Execute in a new cluster" I get one of the following popups for every nested folder:
![image](https://user-images.githubusercontent.com/54575/128038022-e91e87d3-a76d-4311-b810-712c85e86812.png)

I believe that's unnecessary, I know I can't open a terminal for a folder.

This patch is simply to remove this popup window.

Thanks