### PR TITLE
[Feat] Vendor default configuration overrides

### DIFF
--- a/doc/General/Redistribution.md
+++ b/doc/General/Redistribution.md
@@ -1,0 +1,24 @@
+# Redistributing Ásbrú Connection Manager
+
+When redistributing Ásbrú Connection Manager (e.g acting as a vendor), you can customize some aspects of it to better accomodate the specific distribution/environment you are distributing it on.
+
+## Customizing Default Configuration
+
+You can override the default options that are loaded on the first start without having to provide a full configuration file, overriding only the options you need to override.
+
+To do this, create a YAML file on path (relative to project root) `vendor/asbru-conf-default-overrides.yml`.
+
+To discourage accidental usage of this pattern, the YAML document must contain the configurations inside the root key `__PAC__EXPORTED__PARTIAL_CONF`.
+
+An example of this file that changes the default fonts to `Ubuntu Mono 12` is as follows:
+
+```yaml
+---
+__PAC__EXPORTED__PARTIAL_CONF:
+  defaults:
+    info font: Ubuntu Mono 12
+    terminal font: Ubuntu Mono 12
+    tree font: Ubuntu Mono 12
+```
+
+Since this file is used as a source before the application's hard-coded default options, you can also use it to store connections or any other configuration which normally resides in the `asbru.yml` configuration file.

--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -92,6 +92,7 @@ my $RES_DIR = "$RealBin/res";
 # Register icons on Gtk
 #&_registerPACIcons;
 
+my $VENDOR_CFG_FILE = "$RealBin/vendor/asbru-conf-default-overrides.yml";
 my $INIT_CFG_FILE = "$RealBin/res/asbru.yml";
 my $CFG_DIR = $ENV{"ASBRU_CFG"};
 my $CFG_FILE = "$CFG_DIR/asbru.yml";
@@ -3501,6 +3502,21 @@ sub _readConfiguration {
         $continue = 0;
     }
     # END of removing
+
+    # Default partial vendor config, but since it is partial, do not set $continue to 0.
+    if ($continue && -f "${VENDOR_CFG_FILE}") {
+        my $temp_cfg;
+        if (! ($temp_cfg = YAML::LoadFile($VENDOR_CFG_FILE))) {
+            print STDERR "WARNING: Could not load vendor config file '$VENDOR_CFG_FILE': $!\n";
+        } else {
+            print STDERR "INFO: Using vendor config file '$VENDOR_CFG_FILE'\n";
+            $$self{_CFG} //= {};
+            foreach my $config (keys %{ $temp_cfg->{'__PAC__EXPORTED__PARTIAL_CONF'} }) {
+                $$self{_CFG}{$config} = $temp_cfg->{'__PAC__EXPORTED__PARTIAL_CONF'}{$config};
+            }
+            print STDERR "INFO: Used vendor config file '$VENDOR_CFG_FILE'\n";
+        }
+    }
 
     if ($R_CFG_FILE && $continue) {
          print STDERR "WARN: No configuration file in (remote) '$CFG_DIR', creating a new one...\n";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Expect: Managing/Expect.md
       - Jump Server: Managing/JumpServer.md
       - Incognito Browser: Managing/IncognitoBrowser.md
+      - Redistributing: General/Redistribution.md
   - 4. Contributing:
       - Contributing: Contributing/index.md
       - Coding standards: Contributing/CODING_STANDARD.md


### PR DESCRIPTION
Added some code to import configurations on the first start (or when the configuration is otherwise absent) from file `$RealBin/vendor/asbru-conf-default-overrides.yml`, if it exists.

More reasoning behind the feature can be seen in [the new documentation section](https://github.com/henry701/asbru-cm/blob/loki-feat-vendor-defaults/doc/General/Redistribution.md).

Unlike [the original PR](https://github.com/asbru-cm/asbru-cm/pull/848), this does not include any additional dependencies, because there is no need to merge with existing configuration items when there are no existing configuration items in the first place (starting Ásbrú without preexisting configuration).