### PR TITLE
Re-enable Unity tray icon in GTK3

### DIFF
--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -2182,7 +2182,7 @@ sub _setupCallbacks {
             } elsif ($$self{_CFG}{defaults}{'when no more tabs'} == 2) {
                 #hide
                 if ($UNITY) {
-                    $$self{_TRAY}{_TRAY}->set_active();
+                    $$self{_TRAY}{_TRAY}->set_status('active');
                 } else {
                     $$self{_TRAY}{_TRAY}->set_visible(1);
                 }
@@ -2316,7 +2316,7 @@ sub _setupCallbacks {
         if ($$self{_CFG}{defaults}{'close to tray'}) {
             # Show tray icon
             if ($UNITY) {
-                $$self{_TRAY}{_TRAY}->set_active();
+                $$self{_TRAY}{_TRAY}->set_status('active');
             } else {
                 $$self{_TRAY}{_TRAY}->set_visible(1);
             }
@@ -3326,7 +3326,7 @@ sub _quitProgram {
 
     # Hide every GUI component has already finished
     if ($UNITY) {
-        $$self{_TRAY}{_TRAY}->set_passive();
+        $$self{_TRAY}{_TRAY}->set_status('passive');
     } else {
         $$self{_TRAY}{_TRAY}->set_visible(0);     # Hide tray icon?
     }
@@ -3824,7 +3824,7 @@ sub _updateGUIPreferences {
     $$self{_GUI}{descView}->modify_font(Pango::FontDescription::from_string($$self{_CFG}{'defaults'}{'info font'}));
 
     if ($UNITY) {
-        (! $$self{_GUI}{main}->get_visible || $$self{_CFG}{defaults}{'show tray icon'}) ? $$self{_TRAY}{_TRAY}->set_active() : $$self{_TRAY}{_TRAY}->set_passive();
+        (! $$self{_GUI}{main}->get_visible || $$self{_CFG}{defaults}{'show tray icon'}) ? $$self{_TRAY}{_TRAY}->set_status('active') : $$self{_TRAY}{_TRAY}->set_status('passive');
     } else {
         $$self{_TRAY}{_TRAY}->set_visible(! $$self{_GUI}{main}->get_visible() || $$self{_CFG}{defaults}{'show tray icon'});
     }

--- a/lib/PACTrayUnity.pm
+++ b/lib/PACTrayUnity.pm
@@ -42,23 +42,23 @@ use PACUtils;
 
 # AppIndicator
 eval {
-	Glib::Object::Introspection->setup(
-		basename => 'AppIndicator3',
-		version  => '0.1',
-		package  => 'AppIndicator',
-	);
+    Glib::Object::Introspection->setup(
+        basename => 'AppIndicator3',
+        version  => '0.1',
+        package  => 'AppIndicator',
+    );
 };
 if ($@) {
-	eval {
-		Glib::Object::Introspection->setup(
-			basename => 'AyatanaAppIndicator3',
-			version  => '0.1',
-			package  => 'AppIndicator',
-		);
-	};
-	if ($@) {
-		warn "WARNING: AppIndicator is missing --> there will be no icon showing up in the status bar when running Unity!\n\n";
-	}
+    eval {
+        Glib::Object::Introspection->setup(
+            basename => 'AyatanaAppIndicator3',
+            version  => '0.1',
+            package  => 'AppIndicator',
+        );
+    };
+    if ($@) {
+        warn "WARNING: AppIndicator is missing --> there will be no icon showing up in the status bar when running Unity!\n\n";
+    }
 }
 
 # END: Import Modules

--- a/lib/PACTrayUnity.pm
+++ b/lib/PACTrayUnity.pm
@@ -58,6 +58,7 @@ if ($@) {
     };
     if ($@) {
         warn "WARNING: AppIndicator is missing --> there will be no icon showing up in the status bar when running Unity!\n\n";
+        return 0;
     }
 }
 

--- a/lib/PACTrayUnity.pm
+++ b/lib/PACTrayUnity.pm
@@ -36,10 +36,30 @@ use FindBin qw ($RealBin $Bin $Script);
 
 # GTK
 use Gtk3 '-init';
-eval {require Gtk3::AppIndicator;}; $@ and die; # Tricky way to bypass "rpmbuild" necessity to mark this package as a depencency for the RPM... :(
 
 # PAC modules
 use PACUtils;
+
+# AppIndicator
+eval {
+	Glib::Object::Introspection->setup(
+		basename => 'AppIndicator3',
+		version  => '0.1',
+		package  => 'AppIndicator',
+	);
+};
+if ($@) {
+	eval {
+		Glib::Object::Introspection->setup(
+			basename => 'AyatanaAppIndicator3',
+			version  => '0.1',
+			package  => 'AppIndicator',
+		);
+	};
+	if ($@) {
+		warn "WARNING: AppIndicator is missing --> there will be no icon showing up in the status bar when running Unity!\n\n";
+	}
+}
 
 # END: Import Modules
 ###################################################################
@@ -94,9 +114,9 @@ sub DESTROY {
 sub _initGUI {
     my $self = shift;
 
-    $$self{_TRAY} = Gtk3::AppIndicator->new('pac', $TRAYICON);
+    $$self{_TRAY} = AppIndicator::Indicator->new('asbru-cm', $TRAYICON,'application-status');
     $$self{_TRAY}->set_icon_theme_path($RealBin . '/res');
-    $$self{_TRAY}->set_active;
+    $$self{_TRAY}->set_status('active');
     $$self{_MAIN}{_CFG}{'tmp'}{'tray available'} = ! $@;
     return 1;
 }
@@ -121,13 +141,13 @@ sub _setTrayMenu {
         # Check if show password is required
         if ($$self{_MAIN}{_CFG}{'defaults'}{'use gui password'} && $$self{_MAIN}{_CFG}{'defaults'}{'use gui password tray'}) {
             # Trigger the "unlock" procedure
-            $$self{_MAIN}{_GUI}{lockApplicationBtn}->set_active(0);
+            $$self{_MAIN}{_GUI}{lockApplicationBtn}->set_status('passive');
             if (! $$self{_MAIN}{_GUI}{lockApplicationBtn}->get_active()) {
-                $$self{_MAIN}{_CFG}{defaults}{'show tray icon'} ? $$self{_TRAY}->set_active() : $$self{_TRAY}->set_passive();
+                $$self{_MAIN}{_CFG}{defaults}{'show tray icon'} ? $$self{_TRAY}->set_status('active') : $$self{_TRAY}->set_passive();
                 $$self{_MAIN}->_showConnectionsList();
             }
         } else {
-            $$self{_MAIN}{_CFG}{defaults}{'show tray icon'} ? $$self{_TRAY}->set_active() : $$self{_TRAY}->set_passive();
+            $$self{_MAIN}{_CFG}{defaults}{'show tray icon'} ? $$self{_TRAY}->set_status('active') : $$self{_TRAY}->set_passive();
             $$self{_MAIN}->_showConnectionsList();
         }
     }});


### PR DESCRIPTION
New pull request against 'loki' branch.

As I said before, I'm not an expert in Perl or in GTK so change everything you need. This patch re-enables Tray Icon in my Unity Desktop, and works for me. That's all.

Regards.