### PR TITLE
fix: delete script was not working

### DIFF
--- a/lib/PACScripts.pm
+++ b/lib/PACScripts.pm
@@ -1141,7 +1141,7 @@ All $CONNECTIONS{error|out1|out2} are resetted every time a SEND command is exec
         
         # Delete selected files
         foreach my $path (@sel) {
-            my ($file, $name) = $model->get_value($model->get_iter($path), (0));
+            my ($file, $name) = $model->get_value($model->get_iter($path), 0);
             unlink($file);
         }
 

--- a/lib/PACScripts.pm
+++ b/lib/PACScripts.pm
@@ -1137,11 +1137,11 @@ All $CONNECTIONS{error|out1|out2} are resetted every time a SEND command is exec
 
         my @sel = _getSelectedRows($selection);
         return 1 unless scalar(@sel);
-        return 1 unless _wConfirm($$self{_WINDOWSCRIPTS}{main}, "Are you sure you want to remove ". (scalar(@sel) ) . " Ásbrú Scripts?");
-
+        return 1 unless _wConfirm($$self{_WINDOWSCRIPTS}{main}, "Are you sure you want to remove ". (scalar(@sel) ) . " Ásbrú Scripts?");        
+        
         # Delete selected files
         foreach my $path (@sel) {
-            my ($file, $name) = $model->get_value($model->get_iter($path) );
+            my ($file, $name) = $model->get_value($model->get_iter($path), (0));
             unlink($file);
         }
 


### PR DESCRIPTION
A little script deletion fix.
================
Problem: The selected(s) scripts deletion was not working.

Before the change:
----------------------

![image](https://github.com/asbru-cm/asbru-cm/assets/27044623/6b42a910-f2eb-4648-9cdb-db51dd9d3e68)
and of course the scripts was not deleted

After the change
-------------------
No error raised and selected script deleted
