### PR TITLE
Load asbru conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 lib/lib
 lib/res
 .vscode
-


### PR DESCRIPTION
Proposed solution to : #1017

If `~/.ssh/asbru_config` exists we load that one , instead of the current global one.

With this setup power users can basically configure anything they want, specifically for asbru.
