### PR TITLE
generic and simple MFA handling

### DIFF
--- a/lib/PACEdit.pm
+++ b/lib/PACEdit.pm
@@ -386,6 +386,11 @@ sub _setupCallbacks {
         _($self, 'cbCfgQuotePostCommand')->set_sensitive(_($self, 'cbEditPostpendCommand')->get_active());
     });
 
+    # Capture "MFA enabled" checkbox
+    _($self, 'cbEditMFAEnabled')->signal_connect(toggled => sub {
+        _($self, 'hboxEditMFAPrompt')->set_sensitive(_($self, 'cbEditMFAEnabled')->get_active());
+    });
+
     # Capture 'check keepassx' button clicked
     _($self, 'btnCheckKPX')->signal_connect('clicked' => sub {
         if (!$ENV{'KPXC_MP'} && $$self{_CFG}{defaults}{keepass}{password}) {
@@ -752,6 +757,9 @@ sub _updateGUIPreferences {
     _($self, 'entryUUID')->set_text($uuid);
     _($self, 'cbCfgRemoveCtrlChars')->set_active($$self{_CFG}{'environments'}{$uuid}{'remove control chars'});
     _($self, 'cbCfgLogTimestamp')->set_active($$self{_CFG}{'environments'}{$uuid}{'log timestamp'});
+    _($self, 'cbEditMFAEnabled')->set_active($$self{_CFG}{'environments'}{$uuid}{'mfa enabled'} // 0);
+    _($self, 'entryEditMFAPrompt')->set_text($$self{_CFG}{'environments'}{$uuid}{'mfa prompt'} // 'verification code');
+    _($self, 'hboxEditMFAPrompt')->set_sensitive(_($self, 'cbEditMFAEnabled')->get_active());
 
     # Populate 'comboStartScript' combobox
     _($self, 'comboStartScript')->remove_all();
@@ -935,6 +943,8 @@ sub _saveConfiguration {
     $$self{_CFG}{'environments'}{$uuid}{'autossh'} = _($self, 'cbAutossh')->get_active;
     $$self{_CFG}{'environments'}{$uuid}{'remove control chars'} = _($self, 'cbCfgRemoveCtrlChars')->get_active;
     $$self{_CFG}{'environments'}{$uuid}{'log timestamp'} = _($self, 'cbCfgLogTimestamp')->get_active;
+    $$self{_CFG}{'environments'}{$uuid}{'mfa enabled'} = _($self, 'cbEditMFAEnabled')->get_active;
+    $$self{_CFG}{'environments'}{$uuid}{'mfa prompt'} = _($self, 'entryEditMFAPrompt')->get_chars(0, -1);
 
     # Remove lefovers from user in : network connections and authentication
     if ($$self{_CFG}{'environments'}{$uuid}{'auth type'} eq 'userpass') {

--- a/lib/asbru_conn
+++ b/lib/asbru_conn
@@ -184,6 +184,8 @@ my $SOCK_EXEC_FILE = $$CFG{'tmp'}{'socket exec'};
 my $LOG_ENABLED = $$CFG{'environments'}{$UUID}{'save session logs'} ? $$CFG{'environments'}{$UUID}{'save session logs'} : $$CFG{'defaults'}{'save session logs'};
 my $REMOVE_CTRL_CHARS = $$CFG{'environments'}{$UUID}{'remove control chars'} ? $$CFG{'environments'}{$UUID}{'remove control chars'} : $$CFG{'defaults'}{'remove control chars'};
 my $LOG_TIMESTAMP = $$CFG{'environments'}{$UUID}{'log timestamp'} ? $$CFG{'environments'}{$UUID}{'log timestamp'} : $$CFG{'defaults'}{'log timestamp'};
+my $MFA_ENABLED = $$CFG{'environments'}{$UUID}{'mfa enabled'} // 0;
+my $MFA_PROMPT = encode('utf8', $$CFG{'environments'}{$UUID}{'mfa prompt'} // 'verification code');
 my $LPORT;
 
 if (!$RESTART && $IS_CLUSTER) {
@@ -1820,6 +1822,23 @@ elsif (!$MANUAL) {
                 _hardClose($EXP, $UUID);
             }
         }],
+
+        # Found MFA/verification code prompt (if enabled)
+        ($MFA_ENABLED ? (
+            [$MFA_PROMPT, sub {
+                my $mfa_code = wEnterValue('<b>MFA Code Required</b>', "Enter your MFA verification code", '', 0);
+                if (defined $mfa_code) {
+                    $EXP->log_stdout(0);
+                    send_slow($EXP, "$mfa_code\n", 'hide');
+                    $EXP->log_stdout(1);
+                    ctrl("MFA:Sent (not shown)");
+                    exp_continue();
+                } else {
+                    ctrl("CLOSE:MFA:MFA code input cancelled by user");
+                    _hardClose($EXP, $UUID);
+                }
+            }]
+        ) : ()),
 
         # Found user prompt
         [$COMMAND_PROMPT, sub {

--- a/res/asbru.glade
+++ b/res/asbru.glade
@@ -1266,6 +1266,82 @@ If not specified or invalid, the default SSH private key of your system will be 
                             <property name="margin_bottom">5</property>
                             <property name="orientation">vertical</property>
                             <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">5</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbEditMFAEnabled">
+                                        <property name="label" translatable="yes">Enable MFA prompt detection</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hboxEditMFAPrompt">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">  MFA Prompt:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="entryEditMFAPrompt">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Enter the text pattern to expect for MFA prompt (e.g., "verification code")</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkBox" id="hbox57">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>


### PR DESCRIPTION
Add per-connection MFA settings

- Add checkbox to enable/disable MFA prompt detection per connection
- Add text entry to customize the MFA prompt pattern to expect
- Default MFA prompt is 'verification code' when enabled
