### PR TITLE
Fix #1184

### DIFF
--- a/lib/PACMain.pm
+++ b/lib/PACMain.pm
@@ -2046,16 +2046,19 @@ sub _setupCallbacks {
         if (!$tree->_getSelectedUUIDs()) {
             return 1;
         }
+        my $c = 0;
         foreach my $t ($tree->_getSelectedTerminals()) {
             if (($$self{_CFG}{'environments'}{$$t{uuid}}{'_is_group'}) || ($$t{uuid} eq '__PAC__ROOT__')) {
                 my @children = $$self{_GUI}{treeConnections}->_getChildren($$t{uuid}, 0, 1, 1);
                 foreach my $child (@children) {
                     if (!$$self{_CFG}{'environments'}{$$child{uuid}}{'_is_group'}) {
-                        $tmp{$$child{name}} = $$child{uuid};
+                        $tmp{"$$child{name}+$c"} = $$child{uuid};
+                        $c++;
                     }
                 }
             } else {
-                $tmp{$$t{name}} = $$t{uuid};
+                $tmp{"$$t{name}+$c"} = $$t{uuid};
+                $c++;
             }
         }
         foreach my $k (sort keys %tmp) {


### PR DESCRIPTION
Fix #1184 

Regression after adding the sorting by name, it fails if the connections have the same name, typically naming the nodes: server, server, server, etc.

I introduced a counter to make sure names are different in the hash to avoid duplicated names.
